### PR TITLE
Expose Script Code Editor's edit menu

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -38,6 +38,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_edit_menu">
+			<return type="Control" />
+			<description>
+				Returns the edit menu toolbar in the Script Code Editor
+			</description>
+		</method>
 		<method name="get_open_scripts" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -958,6 +958,10 @@ Array ScriptEditor::_get_open_scripts() const {
 	return ret;
 }
 
+Control *ScriptEditor::_get_edit_menu() {
+	return Object::cast_to<ScriptTextEditor>(_get_current_editor())->get_edit_menu();
+}
+
 bool ScriptEditor::toggle_scripts_panel() {
 	list_split->set_visible(!list_split->is_visible());
 	EditorSettings::get_singleton()->set_project_metadata("scripts_panel", "show_scripts_panel", list_split->is_visible());
@@ -3235,6 +3239,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
 	ClassDB::bind_method(D_METHOD("reload_scripts"), &ScriptEditor::reload_scripts);
+	ClassDB::bind_method(D_METHOD("get_edit_menu"), &ScriptEditor::_get_edit_menu);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -398,6 +398,7 @@ class ScriptEditor : public PanelContainer {
 
 	Ref<Script> _get_current_script();
 	Array _get_open_scripts() const;
+	Control *_get_edit_menu();
 
 	Ref<TextFile> _load_text_file(const String &p_path, Error *r_error);
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);


### PR DESCRIPTION
Add new method in ScriptEditor to get edit menu in Script Code Editor.

This can be accessed by plugins to add menu buttons here

![Screenshot from 2023-05-17 17-44-44](https://github.com/ramatakinc/godot/assets/29764541/f9978f14-a1ea-4c51-8fc8-365adcd3206d)

Update
doc/classes/ScriptEditor.xml
editor/plugins/script_editor_plugin.h
editor/plugins/script_editor_plugin.cpp