### PR TITLE
Exposed Script Editor Text Edit Control

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -25,6 +25,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_base_editor" qualifiers="const">
+			<return type="TextEdit" />
+			<description>
+				Returns the underlying TextEdit control used for editing scripts.
+			</description>
+		</method>
 		<method name="get_current_script">
 			<return type="Script" />
 			<description>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -343,6 +343,10 @@ ScriptEditorBase *ScriptEditor::_get_current_editor() const {
 	return Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 }
 
+TextEdit *ScriptEditor::_get_base_editor() const {
+	return Object::cast_to<ScriptTextEditor>(_get_current_editor())->get_code_editor_text_edit();
+}
+
 void ScriptEditor::_update_history_arrows() {
 	script_back->set_disabled(history_pos <= 0);
 	script_forward->set_disabled(history_pos >= history.size() - 1);
@@ -3235,6 +3239,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
 	ClassDB::bind_method(D_METHOD("reload_scripts"), &ScriptEditor::reload_scripts);
+	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditor::_get_base_editor);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -338,6 +338,7 @@ class ScriptEditor : public PanelContainer {
 	void _script_created(Ref<Script> p_script);
 
 	ScriptEditorBase *_get_current_editor() const;
+	TextEdit *_get_base_editor() const;
 
 	void _save_layout();
 	void _editor_settings_changed();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1432,6 +1432,10 @@ Control *ScriptTextEditor::get_edit_menu() {
 	return edit_hb;
 }
 
+TextEdit *ScriptTextEditor::get_code_editor_text_edit() {
+	return code_editor->get_text_edit();
+}
+
 void ScriptTextEditor::clear_edit_menu() {
 	memdelete(edit_hb);
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -33,6 +33,7 @@
 
 #include "scene/gui/color_picker.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/text_edit.h"
 #include "scene/gui/tree.h"
 #include "script_editor_plugin.h"
 
@@ -236,6 +237,7 @@ public:
 	virtual void set_debugger_active(bool p_active);
 
 	Control *get_edit_menu();
+	TextEdit *get_code_editor_text_edit();
 	virtual void clear_edit_menu();
 	static void register_editor();
 


### PR DESCRIPTION
Refactor ScriptEditor and ScriptTextEditor with added method to retrieve the script editor's TextEdit control.

Update
script_editor_plugin.cpp
script_editor_plugin.h
script_text_editor.cpp
script_text_editor.h