### PR TITLE
Add advertisement modules and core scaffolding

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -192,6 +192,7 @@ SConscript("math/SCsub")
 SConscript("crypto/SCsub")
 SConscript("io/SCsub")
 SConscript("bind/SCsub")
+SConscript("ramatak/SCsub")
 
 
 # Build it all as a library

--- a/core/object.h
+++ b/core/object.h
@@ -96,6 +96,7 @@ enum PropertyHint {
 	PROPERTY_HINT_NODE_PATH_VALID_TYPES,
 	PROPERTY_HINT_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
 	PROPERTY_HINT_ENUM_SUGGESTION, ///< hint_text= "val1,val2,val3,etc"
+	PROPERTY_HINT_AD_UNIT,
 	PROPERTY_HINT_MAX,
 	// When updating PropertyHint, also sync the hardcoded list in VisualScriptEditorVariableEdit
 };

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -646,6 +646,9 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == get_name()) {
 		return true;
 	}
+	if (p_feature == "ramatak") {
+		return true;
+	}
 #ifdef DEBUG_ENABLED
 	if (p_feature == "debug") {
 		return true;

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -121,8 +121,8 @@ protected:
 
 	String project_data_dir_name;
 
-	bool _set(const StringName &p_name, const Variant &p_value);
-	bool _get(const StringName &p_name, Variant &r_ret) const;
+	virtual bool _set(const StringName &p_name, const Variant &p_value);
+	virtual bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 	static ProjectSettings *singleton;

--- a/core/ramatak/SCsub
+++ b/core/ramatak/SCsub
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env_templates = env.Clone()
+
+env_templates.add_source_files(env.core_sources, "*.cpp")

--- a/core/ramatak/monetization_settings.cpp
+++ b/core/ramatak/monetization_settings.cpp
@@ -1,0 +1,57 @@
+#include "monetization_settings.h"
+#include "core/project_settings.h"
+
+MonetizationSettings *MonetizationSettings::singleton = nullptr;
+
+MonetizationSettings::MonetizationSettings() {
+	singleton = this;
+}
+
+MonetizationSettings::~MonetizationSettings() {
+}
+
+MonetizationSettings *MonetizationSettings::get_singleton() {
+	return singleton;
+}
+
+void MonetizationSettings::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("delete_ad_unit", "ad_unit"), &MonetizationSettings::delete_ad_unit);
+	ClassDB::bind_method(D_METHOD("set_ad_unit_network_id", "ad_unit", "network", "network_specific_id"), &MonetizationSettings::set_ad_unit_network_id);
+	ClassDB::bind_method(D_METHOD("get_ad_unit_network_id", "ad_unit", "network"), &MonetizationSettings::get_ad_unit_network_id);
+	ClassDB::bind_method(D_METHOD("get_ad_units"), &MonetizationSettings::get_ad_units);
+}
+
+void MonetizationSettings::delete_ad_unit(StringName p_ad_unit) {
+	String ad_unit_setting = "ramatak/monetization/ad_units";
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	Dictionary dict = project_settings->get(ad_unit_setting);
+	Dictionary ad_unit_ids = dict.get(p_ad_unit, Dictionary());
+	ad_unit_ids.erase(p_ad_unit);
+	dict[p_ad_unit] = ad_unit_ids;
+	project_settings->set(ad_unit_setting, dict);
+}
+
+Array MonetizationSettings::get_ad_units() const {
+	return ad_units;
+}
+
+String MonetizationSettings::get_ad_unit_network_id(StringName p_ad_unit, String p_network) {
+	String ad_unit_setting = "ramatak/monetization/ad_units";
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	Dictionary dict = project_settings->get(ad_unit_setting);
+	Dictionary ad_unit_ids = dict[p_ad_unit];
+	return ad_unit_ids.get(p_network, "");
+}
+
+void MonetizationSettings::set_ad_unit_network_id(StringName p_ad_unit, String p_network, String p_id) {
+	String ad_unit_setting = "ramatak/monetization/ad_units";
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	Dictionary dict = project_settings->get(ad_unit_setting);
+	Dictionary ad_unit_ids = dict.get(p_ad_unit, Dictionary());
+	ad_unit_ids[p_network] = p_id;
+	dict[p_ad_unit] = ad_unit_ids;
+	project_settings->set(ad_unit_setting, dict);
+}

--- a/core/ramatak/monetization_settings.h
+++ b/core/ramatak/monetization_settings.h
@@ -1,0 +1,32 @@
+#ifndef _MONETIZATION_SETTINGS_H
+#define _MONETIZATION_SETTINGS_H
+
+#include "core/class_db.h"
+#include "core/object.h"
+#include "servers/ramatak/ad_server.h"
+
+class MonetizationSettings : public Object {
+	GDCLASS(MonetizationSettings, Object);
+
+	Array ad_units;
+
+	static MonetizationSettings *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static MonetizationSettings *get_singleton();
+
+	void delete_ad_unit(StringName p_ad_unit);
+
+	void set_ad_unit_network_id(StringName p_ad_unit, String p_network, String p_id);
+	String get_ad_unit_network_id(StringName p_ad_unit, String p_network);
+
+	Array get_ad_units() const;
+
+	MonetizationSettings();
+	virtual ~MonetizationSettings();
+};
+
+#endif // _MONETIZATION_SETTINGS

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -70,6 +70,7 @@
 #include "core/packed_data_container.h"
 #include "core/path_remap.h"
 #include "core/project_settings.h"
+#include "core/ramatak/monetization_settings.h"
 #include "core/translation.h"
 #include "core/undo_redo.h"
 
@@ -269,6 +270,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("MonetizationSettings", MonetizationSettings::get_singleton()));
 }
 
 void unregister_core_types() {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -15,6 +15,8 @@
 		<member name="ARVRServer" type="ARVRServer" setter="" getter="">
 			The [ARVRServer] singleton.
 		</member>
+		<member name="AdServer" type="AdServer" setter="" getter="">
+		</member>
 		<member name="AudioServer" type="AudioServer" setter="" getter="">
 			The [AudioServer] singleton.
 		</member>

--- a/doc/classes/AdController.xml
+++ b/doc/classes/AdController.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AdController" inherits="Node" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Controls and configures non-banner ads like interstitials
+	</brief_description>
+	<description>
+		AdController is used to set up, display, and monitor the status of an interstitial or rewarded interstitial advertisement.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="hide">
+			<return type="void" />
+			<description>
+				Hides this advertisement.
+			</description>
+		</method>
+		<method name="show">
+			<return type="void" />
+			<description>
+				Shows this advertisement.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="ad_unit" type="String" setter="set_ad_unit" getter="get_ad_unit" default="&quot;&quot;">
+			The ad unit associated with this advertisement.
+			This is used to provide the selected ad network with the information it needs to configure your advertisement and ensure revenue is appropriately handled.
+		</member>
+	</members>
+	<signals>
+		<signal name="ad_clicked">
+			<description>
+				Emitted whenever the advertisement is clicked.
+				Due to platform-specific quirks, this may not be emitted until after the user returns to the app.
+			</description>
+		</signal>
+		<signal name="ad_closed">
+			<description>
+				The user closed the ad.
+			</description>
+		</signal>
+		<signal name="ad_error">
+			<argument index="0" name="message" type="String" />
+			<description>
+				There was an error during the loading or display of this advertisement.
+				The message argument provides more information about the error.
+			</description>
+		</signal>
+		<signal name="ad_loaded">
+			<description>
+				The advertisement has loaded. This does not indicate that it has been shown to the user.
+			</description>
+		</signal>
+		<signal name="ad_reward_earned">
+			<description>
+				For rewarded interstitial ads, this signal indicates that the reward is earned.
+				Handling this signal is mandatory to comply with advertisement network guidelines.
+			</description>
+		</signal>
+		<signal name="ad_shown">
+			<description>
+				The advertisement has been displayed to the user.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/AdServer.xml
+++ b/doc/classes/AdServer.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AdServer" inherits="Object" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		The AdServer is a low-level interface with the Ramtak Mobile Studio advertisement system.
+	</brief_description>
+	<description>
+		While it is possible to use AdServer as a user, it's much more ergonomic to use the AdController and BannerAdController nodes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_available_plugins" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Regurns a list of available plugins in the current build.
+			</description>
+		</method>
+		<method name="get_plugin_priority_order" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns the current priority order of advertisement plugins.
+			</description>
+		</method>
+		<method name="set_plugin_priority_order">
+			<return type="void" />
+			<argument index="0" name="priorities" type="Array" />
+			<description>
+				Sets the priority order of advertisement plugins.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="ad_clicked">
+			<argument index="0" name="request_id" type="int" />
+			<description>
+				Emitted whenever an advertisement is clicked. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+		<signal name="ad_closed">
+			<argument index="0" name="request_id" type="int" />
+			<description>
+				Emitted whenever an advertisement is closed. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+		<signal name="ad_error">
+			<argument index="0" name="request_id" type="int" />
+			<argument index="1" name="message" type="String" />
+			<description>
+				Emitted whenever an advertisement has an error. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+		<signal name="ad_loaded">
+			<argument index="0" name="request_id" type="int" />
+			<description>
+				Emitted whenever an advertisement is loaded. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+		<signal name="ad_reward_earned">
+			<argument index="0" name="request_id" type="int" />
+			<description>
+				Emitted whenever an advertisement reward is earned by the user. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+		<signal name="ad_shown">
+			<argument index="0" name="request_id" type="int" />
+			<description>
+				Emitted whenever an advertisement is shown. You probobaly want to be using the AdController/BannerAdController version of this signal.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="AdType::AD_TYPE_BANNER" value="0" enum="AdType">
+			Indicates a banner ad type.
+		</constant>
+		<constant name="AdType::AD_TYPE_INTERSTITIAL" value="1" enum="AdType">
+			Indicates an interstitial ad type.
+		</constant>
+		<constant name="AdType::AD_TYPE_REWARDED" value="2" enum="AdType">
+			Indicates a rewarded interstitial ad type.
+		</constant>
+		<constant name="BannerAdSize::BANNER_SIZE_SMALL" value="0" enum="BannerAdSize">
+			Indicates a small banner size.
+		</constant>
+		<constant name="BannerAdSize::BANNER_SIZE_LARGE" value="1" enum="BannerAdSize">
+			Indicates a large banner size.
+		</constant>
+		<constant name="BannerAdLocation::BANNER_LOCATION_BOTTOM" value="0" enum="BannerAdLocation">
+			Indicates a banner should be located on the bottom of the screen.
+		</constant>
+		<constant name="BannerAdLocation::BANNER_LOCATION_TOP" value="1" enum="BannerAdLocation">
+			Indicates a banner should be located on the top of the screen.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/BannerAdController.xml
+++ b/doc/classes/BannerAdController.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="BannerAdController" inherits="AdController" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Controls and configures banner ads
+	</brief_description>
+	<description>
+		BannerAdController is used to set up the size, location and status of a banner advertisement, and control its status.
+		It also includes signals inherited from AdController to monitor the status of a banner ad.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="auto_show" type="bool" setter="set_auto_show" getter="get_auto_show" default="false">
+			When auto-show is enabled, the banner advertisement will be displayed to the user when this node enters the scene.
+		</member>
+		<member name="location" type="int" setter="set_location" getter="get_location" enum="AdServer.BannerAdLocation" default="0">
+			The location on the screen to display this banner advertisement.
+		</member>
+		<member name="size" type="int" setter="set_size" getter="get_size" enum="AdServer.BannerAdSize" default="0">
+			The size of the advertisement.
+			This is internally converted to an appropriate value for each ad network to ensure uniform behavior across networks.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/DummyAdPlugin.xml
+++ b/doc/classes/DummyAdPlugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DummyAdPlugin" inherits="AdPlugin" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -110,6 +110,7 @@ if env["tools"]:
     SConscript("icons/SCsub")
     SConscript("import/SCsub")
     SConscript("plugins/SCsub")
+    SConscript("ramatak/SCsub")
 
     lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -36,6 +36,7 @@
 #include "editor_properties_array_dict.h"
 #include "editor_scale.h"
 #include "scene/main/viewport.h"
+#include "editor/ramatak/editor_property_ad_unit.h"
 
 ///////////////////// NULL /////////////////////////
 
@@ -2873,6 +2874,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 				EditorPropertyTextEnum *editor = memnew(EditorPropertyTextEnum);
 				Vector<String> options = p_hint_text.split(",", false);
 				editor->setup(options, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
+				add_property_editor(p_path, editor);
+			} else if (p_hint == PROPERTY_HINT_AD_UNIT) {
+				EditorPropertyAdUnit *editor = memnew(EditorPropertyAdUnit);
+				editor->setup();
 				add_property_editor(p_path, editor);
 			} else if (p_hint == PROPERTY_HINT_MULTILINE_TEXT) {
 				EditorPropertyMultilineText *editor = memnew(EditorPropertyMultilineText);

--- a/editor/export_template_manager.h
+++ b/editor/export_template_manager.h
@@ -127,6 +127,8 @@ public:
 
 	Error install_android_template_from_file(const String &p_file);
 
+	Error install_android_template_from_file_to_path(const String &p_file, const String &p_path);
+
 	void popup_manager();
 
 	ExportTemplateManager();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -2160,6 +2160,10 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor->set_name(TTR("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
 
+	ramatak_settings_editor = memnew(RamatakSettingsEditor);
+	ramatak_settings_editor->set_name(TTR("Ramatak"));
+	tab_container->add_child(ramatak_settings_editor);
+
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
 	timer->connect("timeout", ProjectSettings::get_singleton(), "save");

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -37,6 +37,7 @@
 #include "editor/editor_plugin_settings.h"
 #include "editor/editor_sectioned_inspector.h"
 #include "editor/import_defaults_editor.h"
+#include "editor/ramatak/ramatak_settings_editor.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tab_container.h"
 
@@ -171,6 +172,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	TextureRect *restart_icon;
 	PanelContainer *restart_container;
 	ToolButton *restart_close_button;
+	RamatakSettingsEditor *ramatak_settings_editor = nullptr;
 
 	ImportDefaultsEditor *import_defaults_editor;
 

--- a/editor/ramatak/SCsub
+++ b/editor/ramatak/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/ramatak/editor_property_ad_unit.cpp
+++ b/editor/ramatak/editor_property_ad_unit.cpp
@@ -1,0 +1,62 @@
+#include "editor_property_ad_unit.h"
+
+#include "core/project_settings.h"
+#include "editor/editor_node.h"
+
+void EditorPropertyAdUnit::_option_selected(int p_which) {
+	if (p_which == 0) {
+		emit_changed(get_edited_property(), "");
+	} else {
+		String val = options->get_item_text(p_which);
+		emit_changed(get_edited_property(), val);
+	}
+}
+
+void EditorPropertyAdUnit::_refresh_options() {
+	options->clear();
+	Dictionary ad_units = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	Array new_options = ad_units.keys();
+	options->add_item("[none selected]");
+	for (int i = 0; i < new_options.size(); i++) {
+		String ad_unit_name = new_options[i];
+		if (ad_unit_name.size() == 0) {
+			continue;
+		}
+		options->add_item(ad_unit_name);
+	}
+}
+
+void EditorPropertyAdUnit::update_property() {
+	String ad_unit = get_edited_object()->get(get_edited_property());
+
+	for (int i = 0; i < options->get_item_count(); i++) {
+		if (ad_unit == options->get_item_text(i)) {
+			options->select(i);
+			return;
+		}
+	}
+	options->select(0);
+}
+
+void EditorPropertyAdUnit::setup() {
+	_refresh_options();
+}
+
+void EditorPropertyAdUnit::set_option_button_clip(bool p_enable) {
+	options->set_clip_text(p_enable);
+}
+
+void EditorPropertyAdUnit::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_option_selected"), &EditorPropertyAdUnit::_option_selected);
+	ClassDB::bind_method(D_METHOD("_refresh_options"), &EditorPropertyAdUnit::_refresh_options);
+}
+
+EditorPropertyAdUnit::EditorPropertyAdUnit() {
+	options = memnew(OptionButton);
+	options->set_clip_text(true);
+	options->set_flat(true);
+	add_child(options);
+	add_focusable(options);
+	options->connect("item_selected", this, "_option_selected");
+	ProjectSettings::get_singleton()->connect("project_settings_changed", this, "_refresh_options");
+}

--- a/editor/ramatak/editor_property_ad_unit.h
+++ b/editor/ramatak/editor_property_ad_unit.h
@@ -1,0 +1,24 @@
+#ifndef _EDITOR_PROPERTY_AD_UNIT
+#define _EDITOR_PROPERTY_AD_UNIT
+
+#include "editor/editor_inspector.h"
+#include "scene/gui/option_button.h"
+
+class EditorPropertyAdUnit : public EditorProperty {
+	GDCLASS(EditorPropertyAdUnit, EditorProperty);
+	OptionButton *options = nullptr;
+
+	void _option_selected(int p_which);
+	void _refresh_options();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void setup();
+	virtual void update_property() override;
+	void set_option_button_clip(bool p_enable);
+	EditorPropertyAdUnit();
+};
+
+#endif // _EDITOR_PROPERTY_AD_UNIT

--- a/editor/ramatak/ramatak_settings_editor.cpp
+++ b/editor/ramatak/ramatak_settings_editor.cpp
@@ -1,0 +1,590 @@
+#include "ramatak_settings_editor.h"
+
+#include "core/project_settings.h"
+#include "core/ustring.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+#include "servers/ramatak/ad_plugin.h"
+#include "servers/ramatak/ad_server.h"
+
+const String _AD_UNIT_TYPE_KEY = "ad_unit_type";
+
+void RamatakSettingsAdUnitEditor::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("edited"));
+	ClassDB::bind_method("_ad_unit_edited", &RamatakSettingsAdUnitEditor::_ad_unit_edited);
+}
+
+Dictionary RamatakSettingsAdUnitEditor::get_ad_unit_config() const {
+	Dictionary ad_unit_config;
+	ERR_FAIL_COND_V_MSG(edits.size() != labels.size(), ad_unit_config, "Edits and labels size mismatch.");
+	ad_unit_config[_AD_UNIT_TYPE_KEY] = ad_unit_type_option_button->get_selected_metadata();
+	for (int i = 0; i < edits.size(); i++) {
+		ad_unit_config[plugins[i]] = edits[i]->get_text();
+	}
+	return ad_unit_config;
+}
+
+void RamatakSettingsAdUnitEditor::set_ad_unit(const String &p_ad_unit) {
+	clear();
+	ad_unit = p_ad_unit;
+	Dictionary ad_units = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	Dictionary ad_unit_config = ad_units[ad_unit];
+	// Set up the option button to select ad unit type.
+	{
+		Label *ad_unit_type_label = memnew(Label);
+		ad_unit_type_label->set_text("Ad unit type:");
+		grid_container->add_child(ad_unit_type_label);
+
+		ad_unit_type_option_button = memnew(OptionButton);
+		ad_unit_type_option_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		ad_unit_type_option_button->add_item("Banner");
+		ad_unit_type_option_button->set_item_metadata(0, AdServer::AD_TYPE_BANNER);
+		ad_unit_type_option_button->add_item("Interstitial");
+		ad_unit_type_option_button->set_item_metadata(1, AdServer::AD_TYPE_INTERSTITIAL);
+		ad_unit_type_option_button->add_item("Rewarded");
+		ad_unit_type_option_button->set_item_metadata(2, AdServer::AD_TYPE_REWARDED);
+		{
+			Variant ad_unit_type = ad_unit_config.get(_AD_UNIT_TYPE_KEY, Variant());
+			if (ad_unit_type == (Variant)AdServer::AD_TYPE_BANNER) {
+				ad_unit_type_option_button->select(0);
+			} else if (ad_unit_type == (Variant)AdServer::AD_TYPE_INTERSTITIAL) {
+				ad_unit_type_option_button->select(1);
+			} else if (ad_unit_type == (Variant)AdServer::AD_TYPE_REWARDED) {
+				ad_unit_type_option_button->select(2);
+			} else {
+				// Set to banner by default.
+				ad_unit_config[_AD_UNIT_TYPE_KEY] = (Variant)AdServer::AD_TYPE_BANNER;
+				ad_unit_type_option_button->select(0);
+			}
+		}
+		ad_unit_type_option_button->connect("item_selected", this, "_ad_unit_edited");
+		grid_container->add_child(ad_unit_type_option_button);
+	}
+
+	Array all_plugins = AdServer::get_singleton()->get_available_plugins();
+	for (int i = 0; i < all_plugins.size(); i++) {
+		plugins.push_back(all_plugins[i]);
+
+		Label *label = memnew(Label);
+		label->set_text(vformat(TTR("%s ad unit ID:"), plugins[i]));
+		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_container->add_child(label);
+		labels.push_back(label);
+
+		LineEdit *edit = memnew(LineEdit);
+		edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		edit->connect("text_changed", this, "_ad_unit_edited");
+		grid_container->add_child(edit);
+		edits.push_back(edit);
+		if (ad_unit_config.has(plugins[i])) {
+			edit->set_text(ad_unit_config[plugins[i]]);
+		}
+	}
+}
+
+void RamatakSettingsAdUnitEditor::_ad_unit_edited(Variant p_arg) {
+	emit_signal("edited");
+}
+
+void RamatakSettingsAdUnitEditor::clear() {
+	ad_unit = "";
+	ERR_FAIL_COND_MSG(edits.size() != labels.size(), "Edits and labels size mismatch.");
+	for (int i = 0; i < edits.size(); i++) {
+		LineEdit *edit = edits[i];
+		Label *label = labels[i];
+		edits[i] = nullptr;
+		labels[i] = nullptr;
+		memdelete(edit);
+		memdelete(label);
+	}
+	edits.clear();
+	labels.clear();
+	plugins.clear();
+
+	// Remove any stragglers.
+	while (grid_container->get_child_count() != 0) {
+		Node *child = grid_container->get_child(0);
+		grid_container->remove_child(child);
+		memdelete(child);
+	}
+}
+
+void RamatakSettingsAdUnitEditor::set_disabled(bool p_disabled) {
+	ERR_FAIL_COND_MSG(edits.size() != labels.size(), "Edits and labels size mismatch.");
+	for (int i = 0; i < edits.size(); i++) {
+		edits[i]->set_editable(!p_disabled);
+	}
+}
+
+String RamatakSettingsAdUnitEditor::get_ad_unit() const {
+	return ad_unit;
+}
+
+RamatakSettingsAdUnitEditor::RamatakSettingsAdUnitEditor() {
+	grid_container = memnew(GridContainer);
+	grid_container->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	grid_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid_container->set_columns(2);
+	add_child(grid_container);
+}
+
+void RamatakSettingsAdUnitSetEditor::_bind_methods() {
+	ClassDB::bind_method("_ad_unit_edited", &RamatakSettingsAdUnitSetEditor::_ad_unit_edited);
+	ClassDB::bind_method("_add_edit_text_changed", &RamatakSettingsAdUnitSetEditor::_add_edit_text_changed);
+	ClassDB::bind_method("_add_ad_unit", &RamatakSettingsAdUnitSetEditor::_add_ad_unit);
+	ClassDB::bind_method("_remove_ad_unit", &RamatakSettingsAdUnitSetEditor::_remove_ad_unit);
+	ClassDB::bind_method("_edit_items_list_item_selected", &RamatakSettingsAdUnitSetEditor::_edit_items_list_item_selected);
+	ClassDB::bind_method("_save", &RamatakSettingsAdUnitSetEditor::_save);
+}
+
+void RamatakSettingsAdUnitSetEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		Dictionary ad_units_config = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+		edit_items_list->clear();
+		Array ad_unit_names = ad_units_config.keys();
+		for (int i = 0; i < ad_unit_names.size(); i++) {
+			edit_items_list->add_item(ad_unit_names[i]);
+		}
+		if (ad_unit_names.size() > 0) {
+			edit_items_list->select(0);
+			ad_unit_editor->set_ad_unit(ad_unit_names[0]);
+		}
+		ad_unit_editor->set_ad_unit(ad_unit_editor->get_ad_unit());
+	}
+}
+
+void RamatakSettingsAdUnitSetEditor::_add_edit_text_changed(const String &p_text) {
+	add_button->set_disabled(p_text.empty());
+}
+
+void RamatakSettingsAdUnitSetEditor::_add_ad_unit() {
+	String ad_unit = add_edit->get_text();
+	Dictionary ad_units_config = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	if (ad_units_config.has(ad_unit) || ad_unit == "") {
+		return;
+	}
+	add_edit->set_text("");
+	add_button->set_disabled(true);
+	ad_units_config[ad_unit] = Dictionary();
+	ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", ad_units_config);
+	call_deferred("_save");
+	edit_items_list->add_item(ad_unit);
+}
+
+void RamatakSettingsAdUnitSetEditor::_save() {
+	if (Error::OK != ProjectSettings::get_singleton()->save()) {
+		WARN_PRINT("Failed to save");
+	}
+}
+
+void RamatakSettingsAdUnitSetEditor::_remove_ad_unit() {
+	Dictionary ad_units_config = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	Vector<int> selected_items = edit_items_list->get_selected_items();
+	if (selected_items.size() > 0) {
+		// DEV_ASSERT(ad_unit_editor->get_ad_unit() != "");
+		ad_units_config.erase(ad_unit_editor->get_ad_unit());
+		edit_items_list->remove_item(selected_items.get(0));
+		ad_unit_editor->clear();
+		ad_unit_editor->set_disabled(true);
+	}
+	ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", ad_units_config);
+	call_deferred("_save");
+}
+
+void RamatakSettingsAdUnitSetEditor::_edit_items_list_item_selected(int p_index) {
+	Dictionary previous_ad_unit_config = ad_unit_editor->get_ad_unit_config();
+	Dictionary ad_units_config = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	if (ad_unit_editor->get_ad_unit() != "") {
+		ad_units_config[ad_unit_editor->get_ad_unit()] = previous_ad_unit_config;
+	}
+
+	String ad_unit = edit_items_list->get_item_text(p_index);
+	ad_unit_editor->set_ad_unit(ad_unit);
+	remove_button->set_disabled(false);
+}
+
+void RamatakSettingsAdUnitSetEditor::_ad_unit_edited() {
+	Dictionary current_ad_unit_config = ad_unit_editor->get_ad_unit_config();
+	Dictionary ad_units_config = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_units");
+	if (ad_unit_editor->get_ad_unit() != "") {
+		ad_units_config[ad_unit_editor->get_ad_unit()] = current_ad_unit_config;
+		ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", ad_units_config);
+		call_deferred("_save");
+	}
+}
+
+RamatakSettingsAdUnitSetEditor::RamatakSettingsAdUnitSetEditor() {
+	set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	main_vbox = memnew(VBoxContainer);
+	main_vbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	add_child(main_vbox);
+
+	add_hbox = memnew(HBoxContainer);
+	add_label = memnew(Label);
+	add_label->set_text(TTR("Add Advertisement Unit"));
+	add_hbox->add_child(add_label);
+
+	add_edit = memnew(LineEdit);
+	add_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_edit->set_placeholder(TTR("Name (e.g. level_completed_interstitial)"));
+	add_edit->set_clear_button_enabled(true);
+	add_edit->connect("text_changed", this, "_add_edit_text_changed");
+	add_hbox->add_child(add_edit);
+
+	add_button = memnew(Button);
+	add_button->set_text(TTR("Add"));
+	add_button->set_disabled(true);
+	add_button->connect("pressed", this, "_add_ad_unit");
+	add_hbox->add_child(add_button);
+
+	remove_button = memnew(Button);
+	remove_button->set_text(TTR("Remove"));
+	remove_button->set_disabled(true);
+	remove_button->connect("pressed", this, "_remove_ad_unit");
+	add_hbox->add_child(remove_button);
+
+	main_vbox->add_child(add_hbox);
+
+	edit_hbox = memnew(HBoxContainer);
+	edit_hbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	edit_hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	edit_items_list = memnew(ItemList);
+	edit_items_list->set_custom_minimum_size(Size2(200, 0));
+	edit_items_list->connect("item_selected", this, "_edit_items_list_item_selected", Vector<Variant>(), CONNECT_DEFERRED);
+	edit_hbox->add_child(edit_items_list);
+
+	ad_unit_editor = memnew(RamatakSettingsAdUnitEditor);
+	ad_unit_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	ad_unit_editor->connect("edited", this, "_ad_unit_edited");
+	edit_hbox->add_child(ad_unit_editor);
+
+	main_vbox->add_child(edit_hbox);
+}
+
+RamatakAdPluginSettingsEditor::RamatakAdPluginSettingsEditor() {
+	grid_container = memnew(GridContainer);
+	grid_container->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	grid_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid_container->set_columns(2);
+	add_child(grid_container);
+}
+
+void RamatakAdPluginSettingsEditor::_bind_methods() {
+	ClassDB::bind_method("_setting_edited", &RamatakAdPluginSettingsEditor::_setting_edited);
+}
+
+void RamatakAdPluginSettingsEditor::set_plugin(const String &p_plugin) {
+	clear();
+	plugin_id = p_plugin;
+
+	Ref<AdPlugin> plugin = AdServer::get_singleton()->get_plugin_raw(plugin_id);
+	Array key_tooltip_pairs = plugin->get_config_key_tooltip_pairs();
+	Dictionary ad_plugin_configs = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_config");
+	Dictionary this_plugin_config = ad_plugin_configs[plugin_id];
+	for (int i = 0; i < key_tooltip_pairs.size(); i++) {
+		Array pair = key_tooltip_pairs[i];
+		String key = pair[0];
+		plugin_keys.push_back(key);
+
+		// TODO: Tooltips.
+
+		Label *label = memnew(Label);
+		label->set_text(key);
+		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_container->add_child(label);
+		labels.push_back(label);
+
+		LineEdit *edit = memnew(LineEdit);
+		edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		edit->connect("text_changed", this, "_setting_edited");
+		grid_container->add_child(edit);
+		edits.push_back(edit);
+
+		if (this_plugin_config.has(key)) {
+			edit->set_text(this_plugin_config[key]);
+		}
+	}
+}
+
+void RamatakAdPluginSettingsEditor::_setting_edited(Variant p_arg) {
+	Dictionary ad_plugin_configs = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_config");
+	Dictionary this_plugin_config = ad_plugin_configs[plugin_id];
+
+	Ref<AdPlugin> plugin = AdServer::get_singleton()->get_plugin_raw(plugin_id);
+	Array key_tooltip_pairs = plugin->get_config_key_tooltip_pairs();
+	for (int i = 0; i < key_tooltip_pairs.size(); i++) {
+		Array pair = key_tooltip_pairs[i];
+		String key = pair[0];
+
+		this_plugin_config[key] = edits[i]->get_text();
+	}
+	ad_plugin_configs[plugin_id] = this_plugin_config;
+	ProjectSettings::get_singleton()->set("ramatak/monetization/ad_plugin_config", ad_plugin_configs);
+	ProjectSettings::get_singleton()->save();
+}
+
+void RamatakAdPluginSettingsEditor::clear() {
+	ERR_FAIL_COND_MSG(edits.size() != labels.size(), "Edits and labels size mismatch.");
+	for (int i = 0; i < edits.size(); i++) {
+		LineEdit *edit = edits[i];
+		Label *label = labels[i];
+		edits[i] = nullptr;
+		labels[i] = nullptr;
+		memdelete(edit);
+		memdelete(label);
+	}
+	edits.clear();
+	labels.clear();
+	plugin_keys.clear();
+
+	// Remove any stragglers.
+	while (grid_container->get_child_count() != 0) {
+		Node *child = grid_container->get_child(0);
+		grid_container->remove_child(child);
+		memdelete(child);
+	}
+}
+
+RamatakAdPluginPriorityEditor::RamatakAdPluginPriorityEditor() {
+	main_hbox = memnew(HBoxContainer);
+	main_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	add_child(main_hbox);
+
+	VBoxContainer *disabled_plugins_vbox = memnew(VBoxContainer);
+	disabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_list = memnew(ItemList);
+	disabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	Label *disabled_plugins_label = memnew(Label);
+	disabled_plugins_label->set_text("Disabled plugins");
+
+	disabled_plugins_vbox->add_child(disabled_plugins_label);
+	disabled_plugins_vbox->add_child(disabled_plugins_list);
+	main_hbox->add_child(disabled_plugins_vbox);
+
+	VBoxContainer *enabled_plugins_vbox = memnew(VBoxContainer);
+	enabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_list = memnew(ItemList);
+	enabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	Label *enabled_plugins_label = memnew(Label);
+	enabled_plugins_label->set_text("Enabled plugins");
+
+	enabled_plugins_vbox->add_child(enabled_plugins_label);
+	enabled_plugins_vbox->add_child(enabled_plugins_list);
+	main_hbox->add_child(enabled_plugins_vbox);
+
+	button_row = memnew(VBoxContainer);
+	main_hbox->add_child(button_row);
+
+	increase_prioity = memnew(Button);
+	increase_prioity->set_text("Increase priority");
+	increase_prioity->connect("pressed", this, "_increase_selected_priority");
+	button_row->add_child(increase_prioity);
+
+	decrease_prioity = memnew(Button);
+	decrease_prioity->set_text("Decrease priority");
+	decrease_prioity->connect("pressed", this, "_decrease_selected_priority");
+	button_row->add_child(decrease_prioity);
+
+	enable_plugin = memnew(Button);
+	enable_plugin->set_text("Enable plugin");
+	enable_plugin->connect("pressed", this, "_enable_selected_plugin");
+	button_row->add_child(enable_plugin);
+
+	disable_plugin = memnew(Button);
+	disable_plugin->set_text("Disable plugin");
+	disable_plugin->connect("pressed", this, "_disable_selected_plugin");
+	button_row->add_child(disable_plugin);
+}
+
+void RamatakAdPluginPriorityEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		Array all_plugins = AdServer::get_singleton()->get_available_plugins();
+		Array priority_order = AdServer::get_singleton()->get_plugin_priority_order();
+		for (int i = 0; i < priority_order.size(); i++) {
+			enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(priority_order[i])->get_friendly_name());
+			enabled_plugins_list->set_item_metadata(i, (String)priority_order[i]);
+		}
+		for (int i = 0; i < all_plugins.size(); i++) {
+			if (priority_order.find(all_plugins[i]) == -1) {
+				disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(all_plugins[i])->get_friendly_name());
+				disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, (String)all_plugins[i]);
+			}
+		}
+	}
+}
+
+void RamatakAdPluginPriorityEditor::_bind_methods() {
+	ClassDB::bind_method("_increase_selected_priority", &RamatakAdPluginPriorityEditor::_increase_selected_priority);
+	ClassDB::bind_method("_decrease_selected_priority", &RamatakAdPluginPriorityEditor::_decrease_selected_priority);
+	ClassDB::bind_method("_enable_selected_plugin", &RamatakAdPluginPriorityEditor::_enable_selected_plugin);
+	ClassDB::bind_method("_disable_selected_plugin", &RamatakAdPluginPriorityEditor::_disable_selected_plugin);
+}
+
+int RamatakAdPluginPriorityEditor::get_selected_index(ItemList *p_list) {
+	Vector<int> selected = p_list->get_selected_items();
+	enabled_plugins_list->unselect_all();
+	if (selected.size() > 1) {
+		WARN_PRINT_ONCE("Multi-select is not enabled but multiple items are selected");
+		return -1;
+	} else if (selected.empty()) {
+		return -1;
+	}
+	return selected[0];
+}
+
+void RamatakAdPluginPriorityEditor::persist_settings() {
+	Array priorities;
+	for (int i = 0; i < enabled_plugins_list->get_item_count(); i++) {
+		String id = enabled_plugins_list->get_item_metadata(i);
+		priorities.push_back(id);
+	}
+	AdServer::get_singleton()->set_plugin_priority_order(priorities);
+}
+
+void RamatakAdPluginPriorityEditor::_increase_selected_priority() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	if (selected_index == 0) {
+		return; // Can't move it up any more.
+	}
+	enabled_plugins_list->move_item(selected_index, selected_index - 1);
+	enabled_plugins_list->select(selected_index - 1);
+	persist_settings();
+}
+
+void RamatakAdPluginPriorityEditor::_decrease_selected_priority() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	if (selected_index == enabled_plugins_list->get_item_count() - 1) {
+		return; // Can't move it down any more.
+	}
+	enabled_plugins_list->move_item(selected_index, selected_index + 1);
+	enabled_plugins_list->select(selected_index + 1);
+	persist_settings();
+}
+
+void RamatakAdPluginPriorityEditor::_enable_selected_plugin() {
+	int selected_index = get_selected_index(disabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	String plugin_id = disabled_plugins_list->get_item_metadata(selected_index);
+	disabled_plugins_list->remove_item(selected_index);
+	enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
+	enabled_plugins_list->set_item_metadata(enabled_plugins_list->get_item_count() - 1, plugin_id);
+	persist_settings();
+}
+
+void RamatakAdPluginPriorityEditor::_disable_selected_plugin() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	String plugin_id = enabled_plugins_list->get_item_metadata(selected_index);
+	enabled_plugins_list->remove_item(selected_index);
+	disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
+	disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, plugin_id);
+	persist_settings();
+}
+
+RamatakSettingsEditor::RamatakSettingsEditor() {
+	ad_plugin_settings_editor = memnew(RamatakAdPluginSettingsEditor);
+	ad_plugin_settings_editor->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	ad_plugin_settings_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	ad_unit_set_editor = memnew(RamatakSettingsAdUnitSetEditor);
+	ad_unit_set_editor->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	ad_unit_set_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	ad_priority_editor = memnew(RamatakAdPluginPriorityEditor);
+	ad_priority_editor->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	ad_priority_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	main_hbox = memnew(HBoxContainer);
+	main_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	add_child(main_hbox);
+
+	edit_items_list = memnew(ItemList);
+	edit_items_list->set_custom_minimum_size(Size2(200, 0));
+
+	edit_items_list->add_item("Ad units");
+	edit_items_list->set_item_metadata(edit_items_list->get_item_count() - 1, (Variant)AD_UNITS);
+
+	edit_items_list->add_item("Plugin priorities");
+	edit_items_list->set_item_metadata(edit_items_list->get_item_count() - 1, (Variant)PLUGIN_PRIORITIES);
+
+	edit_items_list->connect("item_selected", this, "_edit_items_list_item_selected");
+	main_hbox->add_child(edit_items_list);
+
+	main_hbox->add_child(ad_unit_set_editor);
+	current_pane = ad_unit_set_editor;
+}
+
+void RamatakSettingsEditor::_bind_methods() {
+	ClassDB::bind_method("_edit_items_list_item_selected", &RamatakSettingsEditor::_edit_items_list_item_selected);
+}
+
+void RamatakSettingsEditor::_edit_items_list_item_selected(int p_index) {
+	if (edit_items_list->get_item_metadata(p_index) == (Variant)AD_UNITS) {
+		if (current_pane) {
+			main_hbox->remove_child(current_pane);
+		}
+
+		current_pane = ad_unit_set_editor;
+		main_hbox->add_child(current_pane);
+
+	} else if (edit_items_list->get_item_metadata(p_index) == (Variant)PLUGIN_PRIORITIES) {
+		if (current_pane) {
+			main_hbox->remove_child(current_pane);
+		}
+		current_pane = this->ad_priority_editor;
+		main_hbox->add_child(current_pane);
+	} else {
+		if (current_pane) {
+			main_hbox->remove_child(current_pane);
+		}
+
+		String plugin = edit_items_list->get_item_metadata(p_index);
+		this->ad_plugin_settings_editor->set_plugin(plugin);
+
+		current_pane = this->ad_plugin_settings_editor;
+		main_hbox->add_child(current_pane);
+	}
+}
+
+void RamatakSettingsEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		plugins = AdServer::get_singleton()->get_available_plugins();
+		for (int i = 0; i < plugins.size(); i++) {
+			if (i == 0) {
+				ad_unit_set_editor->remove_button->set_disabled(false);
+			}
+			Ref<AdPlugin> plugin = AdServer::get_singleton()->get_plugin_raw(plugins[i]);
+			Array key_tooltip_pairs = plugin->get_config_key_tooltip_pairs();
+			if (key_tooltip_pairs.empty()) {
+				continue;
+			}
+			edit_items_list->add_item(vformat("%s options", plugin->get_friendly_name()));
+			// Use the non-friendly name as metadata.
+			edit_items_list->set_item_metadata(edit_items_list->get_item_count() - 1, plugins[i]);
+		}
+		edit_items_list->select(0);
+	}
+}

--- a/editor/ramatak/ramatak_settings_editor.h
+++ b/editor/ramatak/ramatak_settings_editor.h
@@ -1,0 +1,167 @@
+#ifndef _RAMATAK_SETTINGS_EDITOR
+#define _RAMATAK_SETTINGS_EDITOR
+
+#include "scene/gui/control.h"
+
+class HBoxContainer;
+class VBoxContainer;
+class GridContainer;
+class OptionButton;
+class LineEdit;
+class Button;
+class ItemList;
+class Label;
+
+class RamatakSettingsAdUnitEditor : public Control {
+	GDCLASS(RamatakSettingsAdUnitEditor, Control);
+
+	GridContainer *grid_container;
+
+	OptionButton *ad_unit_type_option_button;
+	List<String> plugins;
+	List<Label *> labels;
+	List<LineEdit *> edits;
+
+	String ad_unit;
+
+	void _ad_unit_edited(Variant p_arg);
+
+protected:
+	static void _bind_methods();
+
+public:
+	RamatakSettingsAdUnitEditor();
+
+	void set_disabled(bool p_disabled);
+	void clear();
+
+	Dictionary get_ad_unit_config() const;
+	void set_ad_unit(const String &p_ad_unit);
+	String get_ad_unit() const;
+};
+
+class RamatakSettingsAdUnitSetEditor : public Control {
+	GDCLASS(RamatakSettingsAdUnitSetEditor, Control);
+
+	VBoxContainer *main_vbox = nullptr;
+	HBoxContainer *add_hbox = nullptr;
+	HBoxContainer *edit_hbox = nullptr;
+
+	Label *add_label = nullptr;
+	LineEdit *add_edit = nullptr;
+	Button *add_button = nullptr;
+	Button *remove_button = nullptr;
+
+	ItemList *edit_items_list = nullptr;
+	RamatakSettingsAdUnitEditor *ad_unit_editor = nullptr;
+
+	void _add_edit_text_changed(const String &p_text);
+	void _edit_items_list_item_selected(int p_index);
+	void _ad_unit_edited();
+	void _add_ad_unit();
+	void _remove_ad_unit();
+	void _save();
+
+	friend class RamatakSettingsEditor;
+
+protected:
+	static void
+	_bind_methods();
+	void _notification(int p_what);
+
+public:
+	RamatakSettingsAdUnitSetEditor();
+};
+
+class RamatakAdPluginSettingsEditor : public Control {
+	GDCLASS(RamatakAdPluginSettingsEditor, Control);
+
+	String plugin_id;
+	Array plugin_keys;
+
+	VBoxContainer *main_vbox = nullptr;
+
+	GridContainer *grid_container;
+
+	OptionButton *ad_unit_type_option_button;
+	List<Label *> labels;
+	List<LineEdit *> edits;
+
+	void _edit_items_list_item_selected(int p_index);
+	void _setting_edited(Variant p_arg);
+
+protected:
+	static void _bind_methods();
+
+	void clear();
+
+public:
+	void set_plugin(const String &p_plugin);
+
+	RamatakAdPluginSettingsEditor();
+};
+
+class RamatakAdPluginPriorityEditor : public Control {
+	GDCLASS(RamatakAdPluginPriorityEditor, Control);
+
+	HBoxContainer *main_hbox = nullptr;
+
+	ItemList *disabled_plugins_list = nullptr;
+	ItemList *enabled_plugins_list = nullptr;
+
+	VBoxContainer *button_row = nullptr;
+	Button *increase_prioity = nullptr;
+	Button *decrease_prioity = nullptr;
+	Button *enable_plugin = nullptr;
+	Button *disable_plugin = nullptr;
+
+	int get_selected_index(ItemList *p_list);
+
+	void persist_settings();
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+	void _increase_selected_priority();
+	void _decrease_selected_priority();
+
+	void _enable_selected_plugin();
+	void _disable_selected_plugin();
+
+public:
+	void set_platform(const String &p_platform);
+
+	RamatakAdPluginPriorityEditor();
+};
+
+class RamatakSettingsEditor : public Control {
+	GDCLASS(RamatakSettingsEditor, Control);
+
+	Array plugins;
+
+	HBoxContainer *main_hbox = nullptr;
+	ItemList *edit_items_list = nullptr;
+	RamatakSettingsAdUnitSetEditor *ad_unit_set_editor = nullptr;
+	RamatakAdPluginPriorityEditor *ad_priority_editor = nullptr;
+	RamatakAdPluginSettingsEditor *ad_plugin_settings_editor = nullptr;
+
+	Control *current_pane = nullptr;
+
+	void _edit_items_list_item_selected(int p_index);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+	enum ItemListMetadataKeys {
+		AD_UNITS,
+		PLUGIN_PRIORITIES,
+	};
+
+public:
+	RamatakSettingsEditor();
+};
+
+#endif

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -69,6 +69,7 @@
 #include "servers/navigation_server.h"
 #include "servers/physics_2d_server.h"
 #include "servers/physics_server.h"
+#include "servers/ramatak/ad_server.h"
 #include "servers/register_server_types.h"
 #include "servers/visual_server_callbacks.h"
 
@@ -110,6 +111,7 @@ static ScriptDebugger *script_debugger = nullptr;
 static MessageQueue *message_queue = nullptr;
 
 // Initialized in setup2()
+static AdServer *ad_server = nullptr;
 static AudioServer *audio_server = nullptr;
 static CameraServer *camera_server = nullptr;
 static ARVRServer *arvr_server = nullptr;
@@ -419,6 +421,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			String("Please include this when reporting the bug to the project developer."));
 	GLOBAL_DEF("debug/settings/crash_handler/message.editor",
 			String("Please include this when reporting the bug on: https://github.com/godotengine/godot/issues"));
+	ad_server = memnew(AdServer);
 
 	MAIN_PRINT("Main: Parse CMDLine");
 
@@ -1575,6 +1578,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	register_server_singletons();
 
 	register_driver_types();
+
+	// Must happen after register_module_types()
+	AdServer::get_singleton()->initialize_modules();
 
 	// This loads global classes, so it must happen before custom loaders and savers are registered
 	ScriptServer::init_languages();

--- a/modules/ads/SCsub
+++ b/modules/ads/SCsub
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_ads = env_modules.Clone()
+
+# Godot source files
+env_ads.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/ads/ad_controller.cpp
+++ b/modules/ads/ad_controller.cpp
@@ -1,0 +1,98 @@
+#include "ad_controller.h"
+
+#include "servers/ramatak/ad_server.h"
+
+void AdController::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_ad_unit", "ad_unit"), &AdController::set_ad_unit);
+	ClassDB::bind_method(D_METHOD("get_ad_unit"), &AdController::get_ad_unit);
+
+	ClassDB::bind_method(D_METHOD("show"), &AdController::show);
+	ClassDB::bind_method(D_METHOD("hide"), &AdController::hide);
+
+	ClassDB::bind_method(D_METHOD("_ad_loaded", "request_token"), &AdController::_ad_loaded);
+	ClassDB::bind_method(D_METHOD("_ad_shown", "request_token"), &AdController::_ad_shown);
+	ClassDB::bind_method(D_METHOD("_ad_closed", "request_token"), &AdController::_ad_closed);
+	ClassDB::bind_method(D_METHOD("_ad_clicked", "request_token"), &AdController::_ad_clicked);
+	ClassDB::bind_method(D_METHOD("_ad_reward_earned", "request_token"), &AdController::_ad_reward_earned);
+	ClassDB::bind_method(D_METHOD("_ad_error", "request_token", "message"), &AdController::_ad_error);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "ad_unit", PropertyHint::PROPERTY_HINT_AD_UNIT), "set_ad_unit", "get_ad_unit");
+
+	ADD_SIGNAL(MethodInfo("ad_loaded"));
+	ADD_SIGNAL(MethodInfo("ad_shown"));
+	ADD_SIGNAL(MethodInfo("ad_closed"));
+	ADD_SIGNAL(MethodInfo("ad_clicked"));
+	ADD_SIGNAL(MethodInfo("ad_reward_earned"));
+	ADD_SIGNAL(MethodInfo("ad_error", PropertyInfo(Variant::STRING, "message")));
+}
+void AdController::_notification(int p_what) {
+	if (p_what == NOTIFICATION_EXIT_TREE) {
+		hide();
+	}
+}
+
+void AdController::set_ad_unit(String p_ad_unit) {
+	ad_unit = p_ad_unit;
+}
+
+String AdController::get_ad_unit() const {
+	return ad_unit;
+}
+
+void AdController::show() {
+	if (ad_unit == "") {
+		WARN_PRINT("Attempting to show advertisement, but no ad unit selected.");
+		return;
+	}
+	request_tokens.append(AdServer::get_singleton()->show_other(ad_unit));
+}
+
+void AdController::hide() {
+	AdServer::get_singleton()->hide(ad_unit);
+}
+
+
+void AdController::_ad_loaded(Variant p_request_token) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_loaded");
+	}
+}
+
+void AdController::_ad_shown(Variant p_request_token) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_shown");
+	}
+}
+
+void AdController::_ad_clicked(Variant p_request_token) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_clicked");
+	}
+}
+
+void AdController::_ad_closed(Variant p_request_token) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_closed");
+	}
+}
+
+void AdController::_ad_reward_earned(Variant p_request_token) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_reward_earned");
+	}
+}
+
+void AdController::_ad_error(Variant p_request_token, Variant message) {
+	if (request_tokens.has(p_request_token)) {
+		emit_signal("ad_error", message);
+	}
+}
+
+AdController::AdController() {
+	AdServer::get_singleton()->connect("ad_loaded", this, "_ad_loaded");
+	AdServer::get_singleton()->connect("ad_shown", this, "_ad_shown");
+	AdServer::get_singleton()->connect("ad_clicked", this, "_ad_clicked");
+	AdServer::get_singleton()->connect("ad_closed", this, "_ad_closed");
+	AdServer::get_singleton()->connect("ad_reward_earned", this, "_ad_reward_earned");
+	AdServer::get_singleton()->connect("ad_error", this, "_ad_error");
+}

--- a/modules/ads/ad_controller.h
+++ b/modules/ads/ad_controller.h
@@ -1,0 +1,42 @@
+
+#ifndef _AD_CONTROLLER_H
+#define _AD_CONTROLLER_H
+
+#include "scene/main/node.h"
+#include "core/variant.h"
+
+class AdController : public Node {
+	GDCLASS(AdController, Node);
+
+protected:
+	enum Status {
+		NOT_SHOWN,
+		SHOWING,
+		SHOWN,
+	};
+
+	Status status;
+	Array request_tokens;
+	String ad_unit;
+
+	static void	_bind_methods();
+	void _notification(int p_what);
+
+public:
+	void set_ad_unit(String p_ad_unit);
+	String get_ad_unit() const;
+
+	void show();
+	void hide();
+
+	void _ad_loaded(Variant p_request_token);
+	void _ad_shown(Variant p_request_token);
+	void _ad_clicked(Variant p_request_token);
+	void _ad_closed(Variant p_request_token);
+	void _ad_reward_earned(Variant p_request_token);
+	void _ad_error(Variant p_request_token, Variant p_message);
+
+	AdController();
+};
+
+#endif // _AD_CONTROLLER_H

--- a/modules/ads/banner_ad_controller.cpp
+++ b/modules/ads/banner_ad_controller.cpp
@@ -1,0 +1,59 @@
+#include "banner_ad_controller.h"
+#include "core/engine.h"
+#include "servers/ramatak/ad_server.h"
+
+void BannerAdController::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_auto_show", "auto_show"), &BannerAdController::set_auto_show);
+	ClassDB::bind_method(D_METHOD("get_auto_show"), &BannerAdController::get_auto_show);
+
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &BannerAdController::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &BannerAdController::get_size);
+
+	ClassDB::bind_method(D_METHOD("set_location", "location"), &BannerAdController::set_location);
+	ClassDB::bind_method(D_METHOD("get_location"), &BannerAdController::get_location);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_show"), "set_auto_show", "get_auto_show");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "size", PROPERTY_HINT_ENUM, "Small,Large"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "location", PROPERTY_HINT_ENUM, "Bottom,Top"), "set_location", "get_location");
+}
+void BannerAdController::_notification(int p_what) {
+	AdController::_notification(p_what);
+	if (p_what == NOTIFICATION_READY && auto_show && !Engine::get_singleton()->is_editor_hint()) {
+		show();
+	}
+}
+
+bool BannerAdController::get_auto_show() const {
+	return this->auto_show;
+}
+
+void BannerAdController::set_auto_show(bool p_auto_show) {
+	this->auto_show = p_auto_show;
+}
+
+void BannerAdController::show() {
+	if (ad_unit == "") {
+		WARN_PRINT("Attempting to show banner advertisement, but no ad unit selected.");
+		return;
+	}
+	request_tokens.append(AdServer::get_singleton()->show_banner(ad_unit, size, location));
+}
+
+AdServer::BannerAdSize BannerAdController::get_size() const {
+	return this->size;
+}
+
+void BannerAdController::set_size(AdServer::BannerAdSize p_size) {
+	this->size = p_size;
+}
+
+AdServer::BannerAdLocation BannerAdController::get_location() const {
+	return this->location;
+}
+
+void BannerAdController::set_location(AdServer::BannerAdLocation p_location) {
+	this->location = p_location;
+}
+
+BannerAdController::BannerAdController() :
+		auto_show(false), location(AdServer::BANNER_LOCATION_BOTTOM), size(AdServer::BANNER_SIZE_SMALL) {}

--- a/modules/ads/banner_ad_controller.h
+++ b/modules/ads/banner_ad_controller.h
@@ -1,0 +1,34 @@
+
+#ifndef _BANNER_AD_CONTROLLER_H
+#define _BANNER_AD_CONTROLLER_H
+
+#include "ad_controller.h"
+#include "servers/ramatak/ad_server.h"
+
+class BannerAdController : public AdController {
+	GDCLASS(BannerAdController, AdController);
+
+	bool auto_show;
+	AdServer::BannerAdLocation location;
+	AdServer::BannerAdSize size;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	BannerAdController();
+
+	bool get_auto_show() const;
+	void set_auto_show(bool p_auto_show);
+
+	void show();
+
+	AdServer::BannerAdLocation get_location() const;
+	void set_location(AdServer::BannerAdLocation p_location);
+
+	AdServer::BannerAdSize get_size() const;
+	void set_size(AdServer::BannerAdSize p_size);
+};
+
+#endif // _BANNER_AD_CONTROLLER_H

--- a/modules/ads/config.py
+++ b/modules/ads/config.py
@@ -1,0 +1,6 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass

--- a/modules/ads/register_types.cpp
+++ b/modules/ads/register_types.cpp
@@ -1,0 +1,14 @@
+
+#include "register_types.h"
+
+#include "ad_controller.h"
+#include "banner_ad_controller.h"
+#include "servers/ramatak/ad_server.h"
+
+void register_ads_types() {
+	ClassDB::register_class<AdController>();
+	ClassDB::register_class<BannerAdController>();
+}
+
+void unregister_ads_types() {
+}

--- a/modules/ads/register_types.h
+++ b/modules/ads/register_types.h
@@ -1,0 +1,10 @@
+
+#ifndef ADS_REGISTER_TYPES_H
+#define ADS_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void register_ads_types();
+void unregister_ads_types();
+
+#endif // ADS_REGISTER_TYPES_H

--- a/modules/ads_dummy/SCsub
+++ b/modules/ads_dummy/SCsub
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_ads = env_modules.Clone()
+
+# Godot source files
+env_ads.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/ads_dummy/config.py
+++ b/modules/ads_dummy/config.py
@@ -1,0 +1,6 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass

--- a/modules/ads_dummy/dummy_ad_plugin.cpp
+++ b/modules/ads_dummy/dummy_ad_plugin.cpp
@@ -1,0 +1,70 @@
+#include "dummy_ad_plugin.h"
+#include "core/array.h"
+
+AdPlugin::AdPluginResult DummyAdPlugin::init_plugin() {
+	print_line("[Dummy ad plugin] Initializing.");
+	return AdPluginResult::OK;
+}
+
+AdPlugin::AdPluginResult DummyAdPlugin::show_banner(String p_ad_unit, Variant p_request_token, String p_size, String p_location) {
+	print_line(vformat("[Dummy ad plugin] Showing banner ad unit `%s`", p_ad_unit));
+	Variant ad_unit_variant = p_ad_unit;
+	Variant *args[] = { &ad_unit_variant, &p_request_token };
+	emit_signal("loaded", &args, 2);
+	emit_signal("shown", &args, 2);
+	return AdPluginResult::OK;
+}
+
+AdPlugin::AdPluginResult DummyAdPlugin::show_other(String p_ad_unit, Variant p_request_token, AdServer::AdType p_ad_type) {
+	print_line(vformat("[Dummy ad plugin] Showing other ad unit `%s`", p_ad_unit));
+	Variant ad_unit_variant = p_ad_unit;
+	Variant *args[] = { &ad_unit_variant, &p_request_token };
+	emit_signal("loaded", &args, 2);
+	emit_signal("shown", &args, 2);
+	return AdPluginResult::OK;
+}
+
+AdPlugin::AdPluginResult DummyAdPlugin::hide(String p_ad_unit, Variant p_request_token) {
+	print_line(vformat("[Dummy ad plugin] Hiding ad unit `%s`", p_ad_unit));
+	Variant ad_unit_variant = p_ad_unit;
+	Variant *args[] = { &ad_unit_variant, &p_request_token };
+	emit_signal("hidden", args, 2);
+	return AdPluginResult::OK;
+}
+
+AdPlugin::AdPluginResult DummyAdPlugin::hide_all(Variant p_request_token) {
+	print_line("[Dummy ad plugin] Hiding all ad units.");
+	Array ad_units;
+	List<String> keys;
+	ad_unit_request_tokens.get_key_list(&keys);
+	for (int i = 0; i < keys.size(); i++) {
+		hide(keys[i], p_request_token);
+	}
+	return AdPluginResult::OK;
+}
+
+Array DummyAdPlugin::get_shown_ad_units() {
+	Array ad_units;
+	List<String> keys;
+	ad_unit_request_tokens.get_key_list(&keys);
+	for (int i = 0; i < keys.size(); i++) {
+		ad_units.push_back(keys[i]);
+	}
+	return ad_units;
+}
+
+Array DummyAdPlugin::get_config_key_tooltip_pairs() {
+	Array keys;
+	return keys;
+}
+
+String DummyAdPlugin::get_friendly_name() {
+	return "Dummy";
+}
+
+String DummyAdPlugin::get_android_plugin_config() {
+	return "";
+}
+
+DummyAdPlugin::DummyAdPlugin() {}
+DummyAdPlugin::~DummyAdPlugin() {}

--- a/modules/ads_dummy/dummy_ad_plugin.h
+++ b/modules/ads_dummy/dummy_ad_plugin.h
@@ -1,0 +1,33 @@
+#ifndef _DUMMY_AD_PLUGIN_H
+#define _DUMMY_AD_PLUGIN_H
+
+#include "core/hash_map.h"
+#include "servers/ramatak/ad_plugin.h"
+#include "servers/ramatak/ad_server.h"
+
+class DummyAdPlugin : public AdPlugin {
+	GDCLASS(DummyAdPlugin, AdPlugin)
+
+	HashMap<String, Array> ad_unit_request_tokens;
+
+public:
+	virtual AdPluginResult init_plugin();
+
+	virtual Array get_config_key_tooltip_pairs();
+	virtual String get_friendly_name();
+
+	virtual AdPluginResult show_banner(String p_ad_unit, Variant p_request_token, String p_size, String p_location);
+	virtual AdPluginResult show_other(String p_ad_unit, Variant p_request_token, AdServer::AdType p_ad_type);
+	virtual AdPluginResult hide(String p_ad_unit, Variant p_request_token);
+
+	virtual AdPluginResult hide_all(Variant p_request_token);
+
+	virtual Array get_shown_ad_units();
+
+	virtual String get_android_plugin_config();
+
+	DummyAdPlugin();
+	virtual ~DummyAdPlugin();
+};
+
+#endif // _DUMMY_AD_PLUGIN_H

--- a/modules/ads_dummy/register_types.cpp
+++ b/modules/ads_dummy/register_types.cpp
@@ -1,0 +1,16 @@
+#include "register_types.h"
+
+#include "dummy_ad_plugin.h"
+#include "core/class_db.h"
+#include "servers/ramatak/ad_server.h"
+
+static Ref<DummyAdPlugin> dummy_plugin;
+
+void register_ads_dummy_types() {
+	ClassDB::register_virtual_class<DummyAdPlugin>();
+	dummy_plugin.instance();
+	AdServer::get_singleton()->register_ad_plugin("DUMMY", dummy_plugin);
+}
+
+void unregister_ads_dummy_types() {
+}

--- a/modules/ads_dummy/register_types.h
+++ b/modules/ads_dummy/register_types.h
@@ -1,0 +1,9 @@
+#ifndef ADS_DUMMY_REGISTER_TYPES_H
+#define ADS_DUMMY_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void register_ads_dummy_types();
+void unregister_ads_dummy_types();
+
+#endif // ADS_DUMMY_REGISTER_TYPES_H

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -142,7 +142,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	void _get_permissions(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, Vector<String> &r_permissions);
 
-	void _write_tmp_manifest(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, bool p_debug);
+	void _write_tmp_manifest(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, bool p_debug, const String &p_template_path);
 
 	void _fix_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_manifest, bool p_give_internet);
 
@@ -158,9 +158,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	void load_icon_refs(const Ref<EditorExportPreset> &p_preset, Ref<Image> &icon, Ref<Image> &foreground, Ref<Image> &background);
 
-	void store_image(const LauncherIcon launcher_icon, const Vector<uint8_t> &data);
+	void store_image(const LauncherIcon launcher_icon, const Vector<uint8_t> &data, const String &p_template_path);
 
-	void store_image(const String &export_path, const Vector<uint8_t> &data);
+	void store_image(const String &export_path, const Vector<uint8_t> &data, const String &p_template_path);
 
 	void _copy_icons_to_gradle_project(const Ref<EditorExportPreset> &p_preset,
 			const String &processed_splash_config_xml,
@@ -168,9 +168,12 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 			const Ref<Image> &splash_bg_color_image,
 			const Ref<Image> &main_image,
 			const Ref<Image> &foreground,
-			const Ref<Image> &background);
+			const Ref<Image> &background,
+			const String &p_template_path);
 
 	static Vector<String> get_enabled_abis(const Ref<EditorExportPreset> &p_preset);
+
+	static String get_template_path(const Ref<EditorExportPreset> &p_preset);
 
 public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total);
@@ -210,7 +213,7 @@ public:
 
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const;
 
-	void _update_custom_build_project();
+	void _update_custom_build_project(const String &p_template_path);
 
 	inline bool is_clean_build_required(Vector<PluginConfigAndroid> enabled_plugins) {
 		String plugin_names = PluginConfigAndroid::get_plugins_names(enabled_plugins);
@@ -243,9 +246,9 @@ public:
 
 	Error sign_apk(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &export_path, EditorProgress &ep);
 
-	void _clear_assets_directory();
+	void _clear_assets_directory(const String &p_template_path);
 
-	void _remove_copied_libs();
+	void _remove_copied_libs(const String &p_template_path);
 
 	String join_list(List<String> parts, const String &separator) const;
 

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -96,6 +96,8 @@ struct PluginConfigAndroid {
 
 	static PluginConfigAndroid load_plugin_config(Ref<ConfigFile> config_file, const String &path);
 
+	static PluginConfigAndroid parse_plugin_config(Ref<ConfigFile> config_file, const String &base_path);
+
 	static String get_plugins_binaries(String type, Vector<PluginConfigAndroid> plugins_configs);
 
 	static String get_plugins_custom_maven_repos(Vector<PluginConfigAndroid> plugins_configs);

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "gradle_export_util.h"
+#include "servers/ramatak/ad_server.h"
 
 int _get_android_orientation_value(OS::ScreenOrientation screen_orientation) {
 	switch (screen_orientation) {
@@ -144,14 +145,14 @@ String _android_xml_escape(const String &p_string) {
 }
 
 // Creates strings.xml files inside the gradle project for different locales.
-Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &project_name) {
+Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &project_name, const String &template_path) {
 	print_verbose("Creating strings resources for supported locales for project " + project_name);
 	// Stores the string into the default values directory.
 	String processed_default_xml_string = vformat(godot_project_name_xml_string, _android_xml_escape(project_name));
-	store_string_at_path("res://android/build/res/values/godot_project_name_string.xml", processed_default_xml_string);
+	store_string_at_path(template_path + "/res/values/godot_project_name_string.xml", processed_default_xml_string);
 
 	// Searches the Gradle project res/ directory to find all supported locales
-	DirAccessRef da = DirAccess::open("res://android/build/res");
+	DirAccessRef da = DirAccess::open(template_path + "/res");
 	if (!da) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			print_error("Unable to open Android resources directory.");
@@ -170,7 +171,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 		}
 		String locale = file.replace("values-", "").replace("-r", "_");
 		String property_name = "application/config/name_" + locale;
-		String locale_directory = "res://android/build/res/" + file + "/godot_project_name_string.xml";
+		String locale_directory = template_path + "/res/" + file + "/godot_project_name_string.xml";
 		if (ProjectSettings::get_singleton()->has_setting(property_name)) {
 			String locale_project_name = ProjectSettings::get_singleton()->get(property_name);
 			String processed_xml_string = vformat(godot_project_name_xml_string, _android_xml_escape(locale_project_name));
@@ -259,12 +260,19 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_read_write_storage_permission) {
 	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
 	bool uses_xr = xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR;
+	Array ad_priorities = AdServer::get_singleton()->get_plugin_priority_order();
+	String maybe_add_cleartext_traffic_for_fb = "";
+	if (ad_priorities.has("META")) {
+		maybe_add_cleartext_traffic_for_fb = "        android:usesCleartextTraffic=\"true\"\n";
+	}
+
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
 			"        android:isGame=\"%s\"\n"
 			"        android:hasFragileUserData=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
+			"%s"
 			"        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
 			"        tools:ignore=\"GoogleAppIndexingWarning\"\n"
 			"        android:icon=\"@mipmap/icon\" >\n\n"
@@ -274,7 +282,8 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 			bool_to_string(p_preset->get("user_data_backup/allow")),
 			bool_to_string(p_preset->get("package/classify_as_game")),
 			bool_to_string(p_preset->get("package/retain_data_on_uninstall")),
-			bool_to_string(p_has_read_write_storage_permission));
+			bool_to_string(p_has_read_write_storage_permission),
+			maybe_add_cleartext_traffic_for_fb);
 
 	if (uses_xr) {
 		if (xr_mode_index == XR_MODE_OVR) {
@@ -293,6 +302,16 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 	} else {
 		manifest_application_text += "        <meta-data tools:node=\"remove\" android:name=\"com.oculus.supportedDevices\" />\n";
 	}
+
+	Dictionary admob_config = AdServer::get_singleton()->get_plugin_config("ADMOB");
+	if (ad_priorities.has("ADMOB") && admob_config.has("application_id")) {
+		// Update the meta-data 'android:name' attribute based on whether Admob is required.
+		String admob_app_id = admob_config["application_id"];
+		manifest_application_text += "        <meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" android:value=\"" + admob_app_id + "\" />\n";
+	} else if (ad_priorities.has("ADMOB")) {
+		WARN_PRINT("Missing Admob application_id config setting. Exported game may crash on startup.");
+	}
+
 	manifest_application_text += _get_activity_tag(p_preset);
 	manifest_application_text += "    </application>\n";
 	return manifest_application_text;

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -65,6 +65,7 @@ static const int XR_PASSTHROUGH_OPTIONAL = 1;
 static const int XR_PASSTHROUGH_REQUIRED = 2;
 
 struct CustomExportData {
+	String template_directory;
 	String assets_directory;
 	bool debug;
 	Vector<String> libs;
@@ -93,7 +94,7 @@ Error store_string_at_path(const String &p_path, const String &p_data);
 Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total);
 
 // Creates strings.xml files inside the gradle project for different locales.
-Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &project_name);
+Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &project_name, const String &template_path);
 
 String bool_to_string(bool v);
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -121,6 +121,7 @@ android {
         targetSdkVersion getExportTargetSdkVersion()
 
         missingDimensionStrategy 'products', 'template'
+        multiDexEnabled true
 //CHUNK_ANDROID_DEFAULTCONFIG_BEGIN
 //CHUNK_ANDROID_DEFAULTCONFIG_END
     }

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -11,6 +11,7 @@ SConscript("physics/SCsub")
 SConscript("physics_2d/SCsub")
 SConscript("visual/SCsub")
 SConscript("audio/SCsub")
+SConscript("ramatak/SCsub")
 
 lib = env.add_library("servers", env.servers_sources)
 

--- a/servers/ramatak/SCsub
+++ b/servers/ramatak/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/ramatak/ad_plugin.cpp
+++ b/servers/ramatak/ad_plugin.cpp
@@ -1,0 +1,16 @@
+#include "ad_plugin.h"
+
+void AdPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("init_plugin"), &AdPlugin::init_plugin);
+
+	ClassDB::bind_method(D_METHOD("show_banner", "ad_unit", "request_token", "size", "location"), &AdPlugin::show_banner);
+	ClassDB::bind_method(D_METHOD("show_other", "ad_unit", "request_token"), &AdPlugin::show_other);
+	ClassDB::bind_method(D_METHOD("hide", "ad_unit", "request_token"), &AdPlugin::hide);
+
+	ClassDB::bind_method(D_METHOD("hide_all", "request_token"), &AdPlugin::hide_all);
+
+	BIND_ENUM_CONSTANT(OK);
+	BIND_ENUM_CONSTANT(AUTH_ERROR);
+	BIND_ENUM_CONSTANT(NETWORK_ERROR);
+	BIND_ENUM_CONSTANT(UNSPECIFIED_ERROR);
+}

--- a/servers/ramatak/ad_plugin.h
+++ b/servers/ramatak/ad_plugin.h
@@ -1,0 +1,43 @@
+#ifndef _AD_PLUGIN_H
+#define _AD_PLUGIN_H
+
+#include "core/class_db.h"
+#include "core/math/rect2.h"
+#include "core/reference.h"
+#include "servers/ramatak/ad_server.h"
+
+class AdPlugin : public Reference {
+	GDCLASS(AdPlugin, Reference);
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum AdPluginResult {
+		OK,
+		PLUGIN_NOT_ENABLED_WARN,
+		AUTH_ERROR,
+		NETWORK_ERROR,
+		UNSPECIFIED_ERROR,
+	};
+
+	virtual AdPluginResult init_plugin() = 0;
+
+	virtual Array get_config_key_tooltip_pairs() = 0;
+	virtual String get_friendly_name() = 0;
+
+	virtual AdPluginResult show_other(String p_ad_unit, Variant p_request_token, AdServer::AdType p_ad_type) = 0;
+	virtual AdPluginResult show_banner(String p_ad_unit, Variant p_request_token, String p_size, String p_location) = 0;
+	virtual AdPluginResult hide(String p_ad_unit, Variant p_request_token) = 0;
+
+	virtual AdPluginResult hide_all(Variant p_request_token) = 0;
+
+	virtual Array get_shown_ad_units() = 0;
+	// virtual Rect2i get_safe_zone() = 0;
+
+	virtual String get_android_plugin_config() = 0;
+};
+
+VARIANT_ENUM_CAST(AdPlugin::AdPluginResult);
+
+#endif // _AD_PLUGIN_H

--- a/servers/ramatak/ad_server.cpp
+++ b/servers/ramatak/ad_server.cpp
@@ -1,0 +1,199 @@
+#include "ad_server.h"
+
+#include "core/project_settings.h"
+#include "core/ramatak/monetization_settings.h"
+#include "servers/ramatak/ad_plugin.h"
+
+AdServer *AdServer::singleton = nullptr;
+
+void AdServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_available_plugins"), &AdServer::get_available_plugins);
+
+	ClassDB::bind_method(D_METHOD("set_plugin_priority_order", "priorities"), &AdServer::set_plugin_priority_order);
+	ClassDB::bind_method(D_METHOD("get_plugin_priority_order"), &AdServer::get_plugin_priority_order);
+
+	ClassDB::bind_method(D_METHOD("_ad_loaded", "request_token"), &AdServer::_ad_loaded);
+	ClassDB::bind_method(D_METHOD("_ad_shown", "request_token"), &AdServer::_ad_shown);
+	ClassDB::bind_method(D_METHOD("_ad_clicked", "request_token"), &AdServer::_ad_clicked);
+	ClassDB::bind_method(D_METHOD("_ad_closed", "request_token"), &AdServer::_ad_closed);
+	ClassDB::bind_method(D_METHOD("_ad_reward_earned", "request_token"), &AdServer::_ad_reward_earned);
+	ClassDB::bind_method(D_METHOD("_ad_error", "request_token", "message"), &AdServer::_ad_error);
+
+	ADD_SIGNAL(MethodInfo("ad_loaded", PropertyInfo(Variant::INT, "request_id")));
+	ADD_SIGNAL(MethodInfo("ad_shown", PropertyInfo(Variant::INT, "request_id")));
+	ADD_SIGNAL(MethodInfo("ad_closed", PropertyInfo(Variant::INT, "request_id")));
+	ADD_SIGNAL(MethodInfo("ad_clicked", PropertyInfo(Variant::INT, "request_id")));
+	ADD_SIGNAL(MethodInfo("ad_reward_earned", PropertyInfo(Variant::INT, "request_id")));
+	ADD_SIGNAL(MethodInfo("ad_error", PropertyInfo(Variant::INT, "request_id"), PropertyInfo(Variant::STRING, "message")));
+
+	BIND_ENUM_CONSTANT(AdType::AD_TYPE_BANNER);
+	BIND_ENUM_CONSTANT(AdType::AD_TYPE_INTERSTITIAL);
+	BIND_ENUM_CONSTANT(AdType::AD_TYPE_REWARDED);
+
+	BIND_ENUM_CONSTANT(BannerAdSize::BANNER_SIZE_SMALL);
+	BIND_ENUM_CONSTANT(BannerAdSize::BANNER_SIZE_LARGE);
+
+	BIND_ENUM_CONSTANT(BannerAdLocation::BANNER_LOCATION_BOTTOM);
+	BIND_ENUM_CONSTANT(BannerAdLocation::BANNER_LOCATION_TOP);
+}
+
+void AdServer::register_ad_plugin(String p_name, Ref<AdPlugin> p_plugin) {
+	if (!this->ad_plugins.has(p_name)) {
+		this->ad_plugin_list.push_back(p_name);
+	}
+	this->ad_plugins[p_name] = p_plugin;
+}
+
+void AdServer::initialize_modules() {
+	for (int i = 0; i < ad_plugin_list.size(); i++) {
+		String plugin_name = ad_plugin_list[i];
+		Ref<AdPlugin> plugin = this->ad_plugins[plugin_name];
+		if (plugin.is_null()) {
+			WARN_PRINT_ONCE(vformat("Plugin is null during initialization: %s", plugin_name));
+			continue;
+		}
+		AdPlugin::AdPluginResult result = plugin->init_plugin();
+		switch (result) {
+			case AdPlugin::AdPluginResult::OK:
+				break;
+			case AdPlugin::AdPluginResult::PLUGIN_NOT_ENABLED_WARN:
+				WARN_PRINT(vformat("Plugin not enabled, but requested: %s", plugin_name));
+				continue;
+			case AdPlugin::AdPluginResult::AUTH_ERROR:
+			case AdPlugin::AdPluginResult::NETWORK_ERROR:
+			case AdPlugin::AdPluginResult::UNSPECIFIED_ERROR:
+				WARN_PRINT(vformat("Plugin initialization failed: %s", plugin_name));
+				continue;
+		}
+	}
+}
+
+AdServer *AdServer::get_singleton() {
+	return AdServer::singleton;
+}
+
+Array AdServer::get_available_plugins() const {
+	return this->ad_plugin_list;
+}
+
+Ref<AdPlugin> AdServer::get_plugin_raw(String p_name) {
+	return this->ad_plugins.get(p_name);
+}
+
+Array AdServer::get_plugin_priority_order() const {
+	return ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
+}
+
+void AdServer::set_plugin_priority_order(Array p_priorites) {
+	ProjectSettings::get_singleton()->set("ramatak/monetization/ad_plugin_priorities", p_priorites);
+	ProjectSettings::get_singleton()->save();
+}
+
+Dictionary AdServer::get_plugin_config(String p_plugin) const {
+	Dictionary all_configs = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_config");
+	return all_configs[p_plugin];
+}
+
+Variant AdServer::show_other(String p_ad_unit) {
+	Array ad_plugin_priorities = (Array)ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
+	String ad_unit_setting = "ramatak/monetization/ad_units";
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	Dictionary dict = project_settings->get(ad_unit_setting);
+	Dictionary ad_unit_config = dict[p_ad_unit];
+	int ad_type = (int)ad_unit_config["ad_unit_type"];
+
+	for (int i = 0; i < ad_plugin_priorities.size(); i++) {
+		String network_specific_id = MonetizationSettings::get_singleton()->get_ad_unit_network_id(p_ad_unit, ad_plugin_priorities[i]);
+		if (network_specific_id.length() > 0) {
+			// Plugin `i` can handle the specified ad_unit.
+			Variant request_token = rand.rand() & 0x7FFFFFFF;
+			ad_plugins[ad_plugin_priorities[i]]->show_other(network_specific_id, request_token, (AdServer::AdType)ad_type);
+			return request_token;
+		}
+	}
+	WARN_PRINT_ONCE("No ad plugin is capable of handling ad unit.");
+	// There might be a better return value here.
+	return Variant();
+}
+
+Variant AdServer::show_banner(String p_ad_unit, BannerAdSize p_size, BannerAdLocation p_location) {
+	// This looks gross, and it is, but these values are going to cross an FFI boundary into a plugin and
+	// it's much less error-prone to pass a string than an integer representation of an enum that may
+	// change from minor release to minor release, especially because these plugins might not even be first-party.
+	String size;
+	if (p_size == BannerAdSize::BANNER_SIZE_SMALL) {
+		size = "small";
+	} else if (p_size == BannerAdSize::BANNER_SIZE_LARGE) {
+		size = "large";
+	} else {
+		ERR_FAIL_V_MSG(Variant(), "Ad size not handled");
+	}
+	String location;
+	if (p_location == BannerAdLocation::BANNER_LOCATION_BOTTOM) {
+		location = "bottom";
+	} else if (p_location == BannerAdLocation::BANNER_LOCATION_TOP) {
+		location = "top";
+	} else {
+		ERR_FAIL_V_MSG(Variant(), "Ad location not handled");
+	}
+	Array ad_plugin_priorities = (Array)ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
+	for (int i = 0; i < ad_plugin_priorities.size(); i++) {
+		String network_specific_id = MonetizationSettings::get_singleton()->get_ad_unit_network_id(p_ad_unit, ad_plugin_priorities[i]);
+		if (network_specific_id.length() > 0) {
+			// Plugin `i` can handle the specified ad_unit.
+			Variant request_token = rand.rand() & 0x7FFFFFFF;
+			ad_plugins[ad_plugin_priorities[i]]->show_banner(network_specific_id, request_token, size, location);
+			return request_token;
+		}
+	}
+	WARN_PRINT_ONCE("No ad plugin is capable of handling ad unit.");
+	return Variant();
+}
+
+Variant AdServer::hide(String p_ad_unit) {
+	Array ad_plugin_priorities = ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
+	Variant request_token = rand.rand();
+	// For now just send a hide request to every ad plugin that can handle this ad unit.
+	for (int i = 0; i < ad_plugin_priorities.size(); i++) {
+		String network_specific_id = MonetizationSettings::get_singleton()->get_ad_unit_network_id(p_ad_unit, ad_plugin_priorities[i]);
+		if (network_specific_id.length() > 0) {
+			// Plugin `i` can handle the specified ad_unit.
+			ad_plugins[ad_plugin_priorities[i]]->hide(network_specific_id, request_token);
+		}
+	}
+	return request_token;
+}
+
+void AdServer::_ad_loaded(Variant p_request_token) {
+	emit_signal("ad_loaded", p_request_token);
+}
+
+void AdServer::_ad_shown(Variant p_request_token) {
+	emit_signal("ad_shown", p_request_token);
+}
+
+void AdServer::_ad_clicked(Variant p_request_token) {
+	emit_signal("ad_clicked", p_request_token);
+}
+
+void AdServer::_ad_closed(Variant p_request_token) {
+	emit_signal("ad_closed", p_request_token);
+}
+
+void AdServer::_ad_reward_earned(Variant p_request_token) {
+	emit_signal("ad_reward_earned", p_request_token);
+}
+
+void AdServer::_ad_error(Variant p_request_token, Variant message) {
+	emit_signal("ad_error", p_request_token, message);
+}
+
+AdServer::AdServer() :
+		ad_request_counter(0) {
+	AdServer::singleton = this;
+}
+
+AdServer::~AdServer() {
+	AdServer::singleton = nullptr;
+}

--- a/servers/ramatak/ad_server.h
+++ b/servers/ramatak/ad_server.h
@@ -1,0 +1,81 @@
+#ifndef _AD_SERVER_H
+#define _AD_SERVER_H
+
+#include "core/class_db.h"
+#include "core/list.h"
+#include "core/math/random_pcg.h"
+#include "core/object.h"
+#include "core/reference.h"
+
+class AdPlugin;
+
+class AdServer : public Object {
+	GDCLASS(AdServer, Object);
+
+public:
+	// Add new ad types to the end of this list before *_MAX to avoid messing up existing projects.
+	enum AdType {
+		AD_TYPE_BANNER,
+		AD_TYPE_INTERSTITIAL,
+		AD_TYPE_REWARDED,
+		AD_TYPE_MAX,
+	};
+
+	enum BannerAdSize {
+		BANNER_SIZE_SMALL,
+		BANNER_SIZE_LARGE,
+	};
+
+	enum BannerAdLocation {
+		BANNER_LOCATION_BOTTOM,
+		BANNER_LOCATION_TOP,
+	};
+
+private:
+	static AdServer *singleton;
+
+	RandomPCG rand;
+
+	HashMap<String, Ref<AdPlugin>> ad_plugins;
+	Array ad_plugin_list;
+
+	int64_t ad_request_counter;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static AdServer *get_singleton();
+
+	void initialize_modules();
+
+	void register_ad_plugin(String p_name, Ref<AdPlugin> p_plugin);
+	Ref<AdPlugin> get_plugin_raw(String p_name);
+
+	Array get_available_plugins() const;
+
+	Array get_plugin_priority_order() const;
+	void set_plugin_priority_order(Array p_priorites);
+
+	Dictionary get_plugin_config(String p_plugin) const;
+
+	Variant show_banner(String p_ad_unit, BannerAdSize p_size, BannerAdLocation p_location);
+	Variant show_other(String p_ad_unit);
+	Variant hide(String p_ad_unit);
+
+	void _ad_loaded(Variant p_request_token);
+	void _ad_shown(Variant p_request_token);
+	void _ad_clicked(Variant p_request_token);
+	void _ad_closed(Variant p_request_token);
+	void _ad_reward_earned(Variant p_request_token);
+	void _ad_error(Variant p_request_token, Variant p_message);
+
+	AdServer();
+	virtual ~AdServer();
+};
+
+VARIANT_ENUM_CAST(AdServer::AdType)
+VARIANT_ENUM_CAST(AdServer::BannerAdSize)
+VARIANT_ENUM_CAST(AdServer::BannerAdLocation)
+
+#endif // _AD_SERVER_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -65,6 +65,7 @@
 #include "physics_2d_server.h"
 #include "physics_server.h"
 #include "scene/debugger/script_debugger_remote.h"
+#include "servers/ramatak/ad_server.h"
 #include "visual/shader_types.h"
 #include "visual_server.h"
 
@@ -118,6 +119,8 @@ void register_server_types() {
 	ClassDB::register_virtual_class<Navigation2DServer>();
 	ClassDB::register_class<ARVRServer>();
 	ClassDB::register_class<CameraServer>();
+
+	ClassDB::register_class<AdServer>();
 
 	shader_types = memnew(ShaderTypes);
 
@@ -217,4 +220,5 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Navigation2DServer", Navigation2DServer::get_singleton_mut()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ARVRServer", ARVRServer::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("AdServer", AdServer::get_singleton()));
 }


### PR DESCRIPTION
Big PR, but this brings 3.5.1-ramatak up to date with my latest work.

Building:

- [ ] Test this script prior to marking as ready for review.

```
# May need adjustment for your specific situation/preferences
export VERSION=3.5.1.stable
mkdir gdworkspace
cd gdworkspace
export GDWORKSPACE=$PWD
# Reproducibility note: HEAD as of opening of this PR is c9b31bdb8fa5727e023eb9f4a7fc4185f541fcf2
git clone https://github.com/ramatakinc/ramatak-proprietary-modules
# Reproducibility note: HEAD as of opening of this PR is 853f15ec3e5104dc2a89e868e3e490b88509a6f9
git clone https://github.com/ramatakinc/android-ad-plugins
cd android-ad-plugins
./gradlew assemble
cd ../godot
scons custom_modules=../ramatak-proprietary-modules debug_symbols=yes
scons custom_modules=../ramatak-proprietary-modules platform=android arch=arm64 target=release_debug
pushd platform/android/java
./gradlew generateGodotTemplates
popd
mkdir -p bin/templates/$VERSION/
ln -s $GDWORKSPACE/android-ad-plugins/admob/build/outputs/aar/admob-debug.aar bin/admob.aar
ln -s $GDWORKSPACE/android-ad-plugins/meta/build/outputs/aar/meta-debug.aar bin/meta.aar
ln -s $PWD/bin/android_source.zip bin/templates/$VERSION/android_source.zip
```

Test Plan:

- [ ] Create new project
- [ ] Export project for android and confirm no errors during build or startup.
- [ ] Enter admob application ID and enable admob in the priorities screen. Export again and confirm no errors during build or startup (there will be a crash on startup if you forget to populate the Application ID).
- [ ] Add 3 ad units (interstitial, rewarded and banner) and populate each with the plugin-specific IDs in the ad units settings editor.

Confirm the following:

- [ ] Admob Application ID and ad unit settings for both plugins are persisted across editor restarts.
- [ ] BannerAdController only lists the banner ad unit as an available option in the inspector.
- [ ] AdController only lists the interstitial and rewarded ads as available options in the inspector.

For the following checks, switch between plugins by adjusting the priorities in Project Settings -> Ramatak -> Priorities.

Add a banner ad controller and toggle auto-show on, export project and verify the banner ad loads on startup (may take a few seconds). Confirm on:

- [ ] Meta
- [ ] Admob

Create two buttons to show interstitial and rewarded ads, respectively. Confirm for all three ad types and both plugins that only test ads are shown for debug builds.

- [ ] Meta Banner
- [ ] Admob Banner
- [ ] Meta Interstitial
- [ ] Admob Interstitial
- [ ] Meta Rewarded
- [ ] Admob Rewarded

Connect all signals for all ad types and confirmed they are fired correctly for all ad types and plugins. Clicked ads will only fire a signal once the user returns to the app, for complicated reasons. We'll deal with that when we create an analytics system.

- [ ] Meta Banner
- [ ] Admob Banner
- [ ] Meta Interstitial
- [ ] Admob Interstitial
- [ ] Meta Rewarded
- [ ] Admob Rewarded

TBD: Confirm that prod ads are used in release builds, if Admob even allows that? I don't want my google account deactivated and they're very serious about ad fraud as I understand it.