### PR TITLE
Fix crash in ad unit editor

### DIFF
--- a/editor/ramatak/ramatak_settings_editor.h
+++ b/editor/ramatak/ramatak_settings_editor.h
@@ -15,9 +15,9 @@ class Label;
 class RamatakSettingsAdUnitEditor : public Control {
 	GDCLASS(RamatakSettingsAdUnitEditor, Control);
 
-	GridContainer *grid_container;
+	GridContainer *grid_container = nullptr;
 
-	OptionButton *ad_unit_type_option_button;
+	OptionButton *ad_unit_type_option_button = nullptr;
 	List<String> plugins;
 	List<Label *> labels;
 	List<LineEdit *> edits;


### PR DESCRIPTION
Fix a crashing bug that @WolfgangSenff found while attempting to edit an ad unit after deleting another ad unit.

It also includes an unrelated change that I implemented while debugging to re-select another ad unit when one is removed. I think it's a nice change but it can be safely reverted, the fix is the uninitialized pointers, missing explicit deletion, and the null check.