### PR TITLE
Fix crashing search help issue(s)

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -316,6 +316,10 @@ bool EditorHelpSearch::Runner::_phase_match_classes_init() {
 }
 
 bool EditorHelpSearch::Runner::_phase_match_classes() {
+	if (!iterator_doc) {
+		return true;
+	}
+
 	DocData::ClassDoc &class_doc = iterator_doc->value();
 	if (!_is_class_disabled_by_feature_profile(class_doc.name)) {
 		matches[class_doc.name] = ClassMatch();
@@ -387,6 +391,10 @@ bool EditorHelpSearch::Runner::_phase_class_items_init() {
 }
 
 bool EditorHelpSearch::Runner::_phase_class_items() {
+	if (!iterator_match) {
+		return true;
+	}
+
 	ClassMatch &match = iterator_match->value();
 
 	if (search_flags & SEARCH_SHOW_HIERARCHY) {
@@ -410,7 +418,15 @@ bool EditorHelpSearch::Runner::_phase_member_items_init() {
 }
 
 bool EditorHelpSearch::Runner::_phase_member_items() {
+	if (!iterator_match) {
+		return true;
+	}
+
 	ClassMatch &match = iterator_match->value();
+
+	if (match.doc == NULL) {
+		return true;
+	}
 
 	TreeItem *parent = (search_flags & SEARCH_SHOW_HIERARCHY) ? class_items[match.doc->name] : root_item;
 	for (int i = 0; i < match.methods.size(); i++) {
@@ -467,6 +483,10 @@ void EditorHelpSearch::Runner::_match_item(TreeItem *p_item, const String &p_tex
 }
 
 TreeItem *EditorHelpSearch::Runner::_create_class_hierarchy(const ClassMatch &p_match) {
+	if (p_match.doc == NULL) {
+		return NULL;
+	}
+
 	if (class_items.has(p_match.doc->name)) {
 		return class_items[p_match.doc->name];
 	}


### PR DESCRIPTION
There were several places where the editor's Search Help functionality could potentially crash due to unsafe iterator usage. This PR attempts to fix all of them.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
