### PR TITLE
backported Dictionary::find_key from 3.x

### DIFF
--- a/core/dictionary.cpp
+++ b/core/dictionary.cpp
@@ -136,6 +136,15 @@ bool Dictionary::has_all(const Array &p_keys) const {
 	return true;
 }
 
+Variant Dictionary::find_key(const Variant &p_value) const {
+	for (OrderedHashMap<Variant, Variant, VariantHasher, VariantComparator>::Element E = _p->variant_map.front(); E; E = E.next()) {
+		if (E.value() == p_value) {
+			return E.key();
+		}
+	}
+	return Variant();
+}
+
 bool Dictionary::erase(const Variant &p_key) {
 	return _p->variant_map.erase(p_key);
 }

--- a/core/dictionary.h
+++ b/core/dictionary.h
@@ -66,6 +66,7 @@ public:
 
 	bool has(const Variant &p_key) const;
 	bool has_all(const Array &p_keys) const;
+	Variant find_key(const Variant &p_value) const;
 
 	bool erase(const Variant &p_key);
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -552,6 +552,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2(Dictionary, merge);
 	VCALL_LOCALMEM1R(Dictionary, has);
 	VCALL_LOCALMEM1R(Dictionary, has_all);
+	VCALL_LOCALMEM1R(Dictionary, find_key);
 	VCALL_LOCALMEM1R(Dictionary, erase);
 	VCALL_LOCALMEM0R(Dictionary, hash);
 	VCALL_LOCALMEM0R(Dictionary, keys);
@@ -1930,6 +1931,7 @@ void register_variant_methods() {
 	ADDFUNC2NC(DICTIONARY, NIL, Dictionary, merge, DICTIONARY, "dictionary", BOOL, "overwrite", varray(false));
 	ADDFUNC1R(DICTIONARY, BOOL, Dictionary, has, NIL, "key", varray());
 	ADDFUNC1R(DICTIONARY, BOOL, Dictionary, has_all, ARRAY, "keys", varray());
+	ADDFUNC1R(DICTIONARY, NIL, Dictionary, find_key, NIL, "value", varray());
 	ADDFUNC1RNC(DICTIONARY, BOOL, Dictionary, erase, NIL, "key", varray());
 	ADDFUNC0R(DICTIONARY, INT, Dictionary, hash, varray());
 	ADDFUNC0R(DICTIONARY, ARRAY, Dictionary, keys, varray());

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -115,6 +115,14 @@
 				[b]Note:[/b] Don't erase elements while iterating over the dictionary. You can iterate over the [method keys] array instead.
 			</description>
 		</method>
+		<method name="find_key">
+			<return type="Variant" />
+			<argument index="0" name="value" type="Variant" />
+			<description>
+				Returns the first key whose associated value is equal to [code]value[/code], or [code]null[/code] if no such value is found.
+				[b]Note:[/b] [code]null[/code] is also a valid key. If you have it in your [Dictionary], the [method find_key] method can give misleading results.
+			</description>
+		</method>
 		<method name="get">
 			<return type="Variant" />
 			<argument index="0" name="key" type="Variant" />


### PR DESCRIPTION
Updated
core/dictionary.cpp
core/dictionary.h
core/variant_call.cpp
doc/classes/Dictionary.xml

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
