### PR TITLE
Move ad plugin priority settings to export settings

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1011,9 +1011,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 	}
 
+	Array ramatak_ad_plugin_priorities = p_preset->get("ramatak/monetization/ad_plugin_priorities");
+	if (ramatak_ad_plugin_priorities.size() > 0) {
+		custom_map["ramatak/monetization/ad_plugin_priorities"] = ramatak_ad_plugin_priorities;
+	}
+
 	String config_file = "project.binary";
 	String engine_cfb = EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp" + config_file);
 	ProjectSettings::get_singleton()->save_custom(engine_cfb, custom_map, custom_list);
+
 	Vector<uint8_t> data = FileAccess::get_file_as_array(engine_cfb);
 	DirAccess::remove_file_or_error(engine_cfb);
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -320,6 +320,8 @@ public:
 	virtual void get_platform_features(List<String> *r_features) = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) = 0;
 
+	virtual bool ad_plugins_supported() const = 0;
+
 	EditorExportPlatform();
 };
 
@@ -508,6 +510,10 @@ public:
 
 	int get_chmod_flags() const;
 	void set_chmod_flags(int p_flags);
+
+	virtual bool ad_plugins_supported() const {
+		return false;
+	}
 
 	EditorExportPlatformPC();
 };

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -39,6 +39,7 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version_generated.gen.h"
+#include "editor/ramatak/ramatak_export_settings.h"
 #include "editor_data.h"
 #include "editor_node.h"
 #include "editor_scale.h"
@@ -295,6 +296,21 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	_update_feature_list();
 	_update_export_all();
 	minimum_size_changed();
+
+	for (int i = 0; i < sections->get_tab_count(); i++) {
+		if (sections->get_tab_title(i) == "Ramatak") {
+			sections->remove_child(sections->get_tab_control(i));
+			break;
+		}
+	}
+	if (current->get_platform()->ad_plugins_supported()) {
+		VBoxContainer *ramtak_vb = memnew(VBoxContainer);
+		ramtak_vb->set_name(TTR("Ramatak"));
+		RamatakExportSettingsEditor *ramatak_export_settings = memnew(RamatakExportSettingsEditor);
+		ramatak_export_settings->set_preset(current);
+		ramtak_vb->add_child(ramatak_export_settings);
+		sections->add_child(ramtak_vb);
+	}
 
 	int script_export_mode = current->get_script_export_mode();
 	script_mode->select(script_export_mode);

--- a/editor/ramatak/ramatak_export_settings.cpp
+++ b/editor/ramatak/ramatak_export_settings.cpp
@@ -1,0 +1,177 @@
+#include "ramatak_export_settings.h"
+
+#include "core/project_settings.h"
+#include "core/ustring.h"
+#include "editor/editor_export.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
+#include "servers/ramatak/ad_plugin.h"
+#include "servers/ramatak/ad_server.h"
+
+RamatakExportSettingsEditor::RamatakExportSettingsEditor() {
+	main_hbox = memnew(HBoxContainer);
+	main_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	add_child(main_hbox);
+
+	HSplitContainer *hsplit = memnew(HSplitContainer);
+	hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_hbox->add_child(hsplit);
+
+	VBoxContainer *disabled_plugins_vbox = memnew(VBoxContainer);
+	disabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_list = memnew(ItemList);
+	disabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	Label *disabled_plugins_label = memnew(Label);
+	disabled_plugins_label->set_text("Disabled Plugins:");
+
+	disabled_plugins_vbox->add_child(disabled_plugins_label);
+	disabled_plugins_vbox->add_child(disabled_plugins_list);
+	hsplit->add_child(disabled_plugins_vbox);
+
+	VBoxContainer *enabled_plugins_vbox = memnew(VBoxContainer);
+	enabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_list = memnew(ItemList);
+	enabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	Label *enabled_plugins_label = memnew(Label);
+	enabled_plugins_label->set_text("Enabled Plugins:");
+
+	enabled_plugins_vbox->add_child(enabled_plugins_label);
+	enabled_plugins_vbox->add_child(enabled_plugins_list);
+	hsplit->add_child(enabled_plugins_vbox);
+
+	button_row = memnew(VBoxContainer);
+	main_hbox->add_child(button_row);
+
+	// Make buttons align with the plugin lists.
+	button_row->add_child(memnew(Label(" ")));
+
+	increase_prioity = memnew(Button);
+	increase_prioity->set_text("Increase Priority");
+	increase_prioity->connect("pressed", this, "_increase_selected_priority");
+	button_row->add_child(increase_prioity);
+
+	decrease_prioity = memnew(Button);
+	decrease_prioity->set_text("Decrease Priority");
+	decrease_prioity->connect("pressed", this, "_decrease_selected_priority");
+	button_row->add_child(decrease_prioity);
+
+	enable_plugin = memnew(Button);
+	enable_plugin->set_text("Enable Plugin");
+	enable_plugin->connect("pressed", this, "_enable_selected_plugin");
+	button_row->add_child(enable_plugin);
+
+	disable_plugin = memnew(Button);
+	disable_plugin->set_text("Disable Plugin");
+	disable_plugin->connect("pressed", this, "_disable_selected_plugin");
+	button_row->add_child(disable_plugin);
+}
+
+void RamatakExportSettingsEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		Array all_plugins = AdServer::get_singleton()->get_available_plugins();
+		Array priority_order = preset->get("ramatak/monetization/ad_plugin_priorities");
+		for (int i = 0; i < priority_order.size(); i++) {
+			enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(priority_order[i])->get_friendly_name());
+			enabled_plugins_list->set_item_metadata(i, (String)priority_order[i]);
+		}
+		for (int i = 0; i < all_plugins.size(); i++) {
+			if (priority_order.find(all_plugins[i]) == -1) {
+				disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(all_plugins[i])->get_friendly_name());
+				disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, (String)all_plugins[i]);
+			}
+		}
+	}
+}
+
+void RamatakExportSettingsEditor::_bind_methods() {
+	ClassDB::bind_method("_increase_selected_priority", &RamatakExportSettingsEditor::_increase_selected_priority);
+	ClassDB::bind_method("_decrease_selected_priority", &RamatakExportSettingsEditor::_decrease_selected_priority);
+	ClassDB::bind_method("_enable_selected_plugin", &RamatakExportSettingsEditor::_enable_selected_plugin);
+	ClassDB::bind_method("_disable_selected_plugin", &RamatakExportSettingsEditor::_disable_selected_plugin);
+}
+
+int RamatakExportSettingsEditor::get_selected_index(ItemList *p_list) {
+	Vector<int> selected = p_list->get_selected_items();
+	enabled_plugins_list->unselect_all();
+	if (selected.size() > 1) {
+		WARN_PRINT_ONCE("Multi-select is not enabled but multiple items are selected");
+		return -1;
+	} else if (selected.empty()) {
+		return -1;
+	}
+	return selected[0];
+}
+
+void RamatakExportSettingsEditor::persist_settings() {
+	Array priorities;
+	for (int i = 0; i < enabled_plugins_list->get_item_count(); i++) {
+		String id = enabled_plugins_list->get_item_metadata(i);
+		priorities.push_back(id);
+	}
+	preset->set("ramatak/monetization/ad_plugin_priorities", priorities);
+}
+
+void RamatakExportSettingsEditor::_increase_selected_priority() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	if (selected_index == 0) {
+		return; // Can't move it up any more.
+	}
+	enabled_plugins_list->move_item(selected_index, selected_index - 1);
+	enabled_plugins_list->select(selected_index - 1);
+	persist_settings();
+}
+
+void RamatakExportSettingsEditor::_decrease_selected_priority() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	if (selected_index == enabled_plugins_list->get_item_count() - 1) {
+		return; // Can't move it down any more.
+	}
+	enabled_plugins_list->move_item(selected_index, selected_index + 1);
+	enabled_plugins_list->select(selected_index + 1);
+	persist_settings();
+}
+
+void RamatakExportSettingsEditor::_enable_selected_plugin() {
+	int selected_index = get_selected_index(disabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	String plugin_id = disabled_plugins_list->get_item_metadata(selected_index);
+	disabled_plugins_list->remove_item(selected_index);
+	enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
+	enabled_plugins_list->set_item_metadata(enabled_plugins_list->get_item_count() - 1, plugin_id);
+	persist_settings();
+}
+
+void RamatakExportSettingsEditor::_disable_selected_plugin() {
+	int selected_index = get_selected_index(enabled_plugins_list);
+	if (selected_index == -1) {
+		return;
+	}
+	String plugin_id = enabled_plugins_list->get_item_metadata(selected_index);
+	enabled_plugins_list->remove_item(selected_index);
+	disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
+	disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, plugin_id);
+	persist_settings();
+}
+
+void RamatakExportSettingsEditor::set_preset(Ref<EditorExportPreset> p_preset) {
+	preset = p_preset;
+}

--- a/editor/ramatak/ramatak_export_settings.h
+++ b/editor/ramatak/ramatak_export_settings.h
@@ -1,0 +1,55 @@
+#ifndef _RAMATAK_SETTINGS_EDITOR
+#define _RAMATAK_SETTINGS_EDITOR
+
+#include "scene/gui/control.h"
+#include "scene/gui/split_container.h"
+#include "scene/gui/tree.h"
+
+class HBoxContainer;
+class VBoxContainer;
+class GridContainer;
+class OptionButton;
+class LineEdit;
+class Button;
+class ItemList;
+class Label;
+class EditorExportPreset;
+
+class RamatakExportSettingsEditor : public Control {
+	GDCLASS(RamatakExportSettingsEditor, Control);
+
+	HBoxContainer *main_hbox = nullptr;
+
+	ItemList *disabled_plugins_list = nullptr;
+	ItemList *enabled_plugins_list = nullptr;
+
+	VBoxContainer *button_row = nullptr;
+	Button *increase_prioity = nullptr;
+	Button *decrease_prioity = nullptr;
+	Button *enable_plugin = nullptr;
+	Button *disable_plugin = nullptr;
+
+	Ref<EditorExportPreset> preset;
+
+	int get_selected_index(ItemList *p_list);
+
+	void persist_settings();
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+	void _increase_selected_priority();
+	void _decrease_selected_priority();
+
+	void _enable_selected_plugin();
+	void _disable_selected_plugin();
+
+public:
+	void set_preset(Ref<EditorExportPreset> p_preset);
+
+	RamatakExportSettingsEditor();
+};
+
+#endif

--- a/editor/ramatak/ramatak_settings_editor.cpp
+++ b/editor/ramatak/ramatak_settings_editor.cpp
@@ -387,165 +387,6 @@ void RamatakAdPluginSettingsEditor::clear() {
 	}
 }
 
-RamatakAdPluginPriorityEditor::RamatakAdPluginPriorityEditor() {
-	main_hbox = memnew(HBoxContainer);
-	main_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
-	add_child(main_hbox);
-
-	HSplitContainer *hsplit = memnew(HSplitContainer);
-	hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	main_hbox->add_child(hsplit);
-
-	VBoxContainer *disabled_plugins_vbox = memnew(VBoxContainer);
-	disabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	disabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	disabled_plugins_list = memnew(ItemList);
-	disabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	disabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-
-	Label *disabled_plugins_label = memnew(Label);
-	disabled_plugins_label->set_text("Disabled Plugins:");
-
-	disabled_plugins_vbox->add_child(disabled_plugins_label);
-	disabled_plugins_vbox->add_child(disabled_plugins_list);
-	hsplit->add_child(disabled_plugins_vbox);
-
-	VBoxContainer *enabled_plugins_vbox = memnew(VBoxContainer);
-	enabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	enabled_plugins_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	enabled_plugins_list = memnew(ItemList);
-	enabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	enabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-
-	Label *enabled_plugins_label = memnew(Label);
-	enabled_plugins_label->set_text("Enabled Plugins:");
-
-	enabled_plugins_vbox->add_child(enabled_plugins_label);
-	enabled_plugins_vbox->add_child(enabled_plugins_list);
-	hsplit->add_child(enabled_plugins_vbox);
-
-	button_row = memnew(VBoxContainer);
-	main_hbox->add_child(button_row);
-
-	// Make buttons align with the plugin lists.
-	button_row->add_child(memnew(Label(" ")));
-
-	increase_prioity = memnew(Button);
-	increase_prioity->set_text("Increase Priority");
-	increase_prioity->connect("pressed", this, "_increase_selected_priority");
-	button_row->add_child(increase_prioity);
-
-	decrease_prioity = memnew(Button);
-	decrease_prioity->set_text("Decrease Priority");
-	decrease_prioity->connect("pressed", this, "_decrease_selected_priority");
-	button_row->add_child(decrease_prioity);
-
-	enable_plugin = memnew(Button);
-	enable_plugin->set_text("Enable Plugin");
-	enable_plugin->connect("pressed", this, "_enable_selected_plugin");
-	button_row->add_child(enable_plugin);
-
-	disable_plugin = memnew(Button);
-	disable_plugin->set_text("Disable Plugin");
-	disable_plugin->connect("pressed", this, "_disable_selected_plugin");
-	button_row->add_child(disable_plugin);
-}
-
-void RamatakAdPluginPriorityEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_READY) {
-		Array all_plugins = AdServer::get_singleton()->get_available_plugins();
-		Array priority_order = AdServer::get_singleton()->get_plugin_priority_order();
-		for (int i = 0; i < priority_order.size(); i++) {
-			enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(priority_order[i])->get_friendly_name());
-			enabled_plugins_list->set_item_metadata(i, (String)priority_order[i]);
-		}
-		for (int i = 0; i < all_plugins.size(); i++) {
-			if (priority_order.find(all_plugins[i]) == -1) {
-				disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(all_plugins[i])->get_friendly_name());
-				disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, (String)all_plugins[i]);
-			}
-		}
-	}
-}
-
-void RamatakAdPluginPriorityEditor::_bind_methods() {
-	ClassDB::bind_method("_increase_selected_priority", &RamatakAdPluginPriorityEditor::_increase_selected_priority);
-	ClassDB::bind_method("_decrease_selected_priority", &RamatakAdPluginPriorityEditor::_decrease_selected_priority);
-	ClassDB::bind_method("_enable_selected_plugin", &RamatakAdPluginPriorityEditor::_enable_selected_plugin);
-	ClassDB::bind_method("_disable_selected_plugin", &RamatakAdPluginPriorityEditor::_disable_selected_plugin);
-}
-
-int RamatakAdPluginPriorityEditor::get_selected_index(ItemList *p_list) {
-	Vector<int> selected = p_list->get_selected_items();
-	enabled_plugins_list->unselect_all();
-	if (selected.size() > 1) {
-		WARN_PRINT_ONCE("Multi-select is not enabled but multiple items are selected");
-		return -1;
-	} else if (selected.empty()) {
-		return -1;
-	}
-	return selected[0];
-}
-
-void RamatakAdPluginPriorityEditor::persist_settings() {
-	Array priorities;
-	for (int i = 0; i < enabled_plugins_list->get_item_count(); i++) {
-		String id = enabled_plugins_list->get_item_metadata(i);
-		priorities.push_back(id);
-	}
-	AdServer::get_singleton()->set_plugin_priority_order(priorities);
-}
-
-void RamatakAdPluginPriorityEditor::_increase_selected_priority() {
-	int selected_index = get_selected_index(enabled_plugins_list);
-	if (selected_index == -1) {
-		return;
-	}
-	if (selected_index == 0) {
-		return; // Can't move it up any more.
-	}
-	enabled_plugins_list->move_item(selected_index, selected_index - 1);
-	enabled_plugins_list->select(selected_index - 1);
-	persist_settings();
-}
-
-void RamatakAdPluginPriorityEditor::_decrease_selected_priority() {
-	int selected_index = get_selected_index(enabled_plugins_list);
-	if (selected_index == -1) {
-		return;
-	}
-	if (selected_index == enabled_plugins_list->get_item_count() - 1) {
-		return; // Can't move it down any more.
-	}
-	enabled_plugins_list->move_item(selected_index, selected_index + 1);
-	enabled_plugins_list->select(selected_index + 1);
-	persist_settings();
-}
-
-void RamatakAdPluginPriorityEditor::_enable_selected_plugin() {
-	int selected_index = get_selected_index(disabled_plugins_list);
-	if (selected_index == -1) {
-		return;
-	}
-	String plugin_id = disabled_plugins_list->get_item_metadata(selected_index);
-	disabled_plugins_list->remove_item(selected_index);
-	enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
-	enabled_plugins_list->set_item_metadata(enabled_plugins_list->get_item_count() - 1, plugin_id);
-	persist_settings();
-}
-
-void RamatakAdPluginPriorityEditor::_disable_selected_plugin() {
-	int selected_index = get_selected_index(enabled_plugins_list);
-	if (selected_index == -1) {
-		return;
-	}
-	String plugin_id = enabled_plugins_list->get_item_metadata(selected_index);
-	enabled_plugins_list->remove_item(selected_index);
-	disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
-	disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, plugin_id);
-	persist_settings();
-}
-
 RamatakSettingsEditor::RamatakSettingsEditor() {
 	if (!ProjectSettings::get_singleton()->has_setting("ramatak/monetization/ad_units")) {
 		ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", Dictionary());
@@ -584,9 +425,6 @@ RamatakSettingsEditor::RamatakSettingsEditor() {
 	edit_items_list->add_item("Ad Units");
 	edit_items_list->set_item_metadata(edit_items_list->get_item_count() - 1, (Variant)AD_UNITS);
 
-	edit_items_list->add_item("Plugin Priorities");
-	edit_items_list->set_item_metadata(edit_items_list->get_item_count() - 1, (Variant)PLUGIN_PRIORITIES);
-
 	edit_items_list->connect("item_selected", this, "_edit_items_list_item_selected");
 	main_hsplit->add_child(edit_items_list);
 
@@ -605,13 +443,6 @@ void RamatakSettingsEditor::_edit_items_list_item_selected(int p_index) {
 		}
 
 		current_pane = ad_unit_set_editor;
-		main_hsplit->add_child(current_pane);
-
-	} else if (edit_items_list->get_item_metadata(p_index) == (Variant)PLUGIN_PRIORITIES) {
-		if (current_pane) {
-			main_hsplit->remove_child(current_pane);
-		}
-		current_pane = this->ad_priority_editor;
 		main_hsplit->add_child(current_pane);
 	} else {
 		if (current_pane) {

--- a/editor/ramatak/ramatak_settings_editor.h
+++ b/editor/ramatak/ramatak_settings_editor.h
@@ -106,37 +106,6 @@ public:
 
 class RamatakAdPluginPriorityEditor : public Control {
 	GDCLASS(RamatakAdPluginPriorityEditor, Control);
-
-	HBoxContainer *main_hbox = nullptr;
-
-	ItemList *disabled_plugins_list = nullptr;
-	ItemList *enabled_plugins_list = nullptr;
-
-	VBoxContainer *button_row = nullptr;
-	Button *increase_prioity = nullptr;
-	Button *decrease_prioity = nullptr;
-	Button *enable_plugin = nullptr;
-	Button *disable_plugin = nullptr;
-
-	int get_selected_index(ItemList *p_list);
-
-	void persist_settings();
-
-protected:
-	static void _bind_methods();
-
-	void _notification(int p_what);
-
-	void _increase_selected_priority();
-	void _decrease_selected_priority();
-
-	void _enable_selected_plugin();
-	void _disable_selected_plugin();
-
-public:
-	void set_platform(const String &p_platform);
-
-	RamatakAdPluginPriorityEditor();
 };
 
 class RamatakSettingsEditor : public Control {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -358,7 +358,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 								d.description += "Chipset: " + p.get_slice("=", 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.opengles.version=")) {
 								uint32_t opengl = p.get_slice("=", 1).to_int();
-								d.description += "OpenGL: " + itos(opengl >> 16) + "." + itos((opengl >> 8) & 0xFF) + "." + itos((opengl)&0xFF) + "\n";
+								d.description += "OpenGL: " + itos(opengl >> 16) + "." + itos((opengl >> 8) & 0xFF) + "." + itos((opengl) & 0xFF) + "\n";
 							}
 						}
 
@@ -1766,6 +1766,8 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "apk_expansion/enable"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "apk_expansion/SALT"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "apk_expansion/public_key", PROPERTY_HINT_MULTILINE_TEXT), ""));
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "ramatak/monetization/ad_plugin_priorities"), Dictionary()));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::POOL_STRING_ARRAY, "permissions/custom_permissions"), PoolStringArray()));
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -257,6 +257,10 @@ public:
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features);
 
+	virtual bool ad_plugins_supported() const {
+		return true;
+	}
+
 	EditorExportPlatformAndroid();
 
 	~EditorExportPlatformAndroid();

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -298,6 +298,10 @@ public:
 
 		return enabled_plugins;
 	}
+
+	virtual bool ad_plugins_supported() const {
+		return false;
+	}
 };
 
 void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -348,6 +348,10 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {
 	}
 
+	virtual bool ad_plugins_supported() const {
+		return false;
+	}
+
 	EditorExportPlatformJavaScript();
 	~EditorExportPlatformJavaScript();
 };

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -131,6 +131,10 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {
 	}
 
+	virtual bool ad_plugins_supported() const {
+		return false;
+	}
+
 	EditorExportPlatformOSX();
 	~EditorExportPlatformOSX();
 };

--- a/servers/ramatak/ad_server.cpp
+++ b/servers/ramatak/ad_server.cpp
@@ -9,7 +9,6 @@ AdServer *AdServer::singleton = nullptr;
 void AdServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_available_plugins"), &AdServer::get_available_plugins);
 
-	ClassDB::bind_method(D_METHOD("set_plugin_priority_order", "priorities"), &AdServer::set_plugin_priority_order);
 	ClassDB::bind_method(D_METHOD("get_plugin_priority_order"), &AdServer::get_plugin_priority_order);
 
 	ClassDB::bind_method(D_METHOD("_ad_loaded", "request_token"), &AdServer::_ad_loaded);
@@ -82,11 +81,6 @@ Ref<AdPlugin> AdServer::get_plugin_raw(String p_name) {
 
 Array AdServer::get_plugin_priority_order() const {
 	return ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
-}
-
-void AdServer::set_plugin_priority_order(Array p_priorites) {
-	ProjectSettings::get_singleton()->set("ramatak/monetization/ad_plugin_priorities", p_priorites);
-	ProjectSettings::get_singleton()->save();
 }
 
 Dictionary AdServer::get_plugin_config(String p_plugin) const {


### PR DESCRIPTION
This should enable users to have different plugin priorities for different platforms, and different plugin priorities for different export presets (e.g. for different regions).

Test plan
- [x] Confirm that the "Ramatak" tab is present for Android exports, but not other platforms
- [x] Confirm changes are persisted to export_presets.cfg
- [x] Confirm exported games have the plugin priorities setting moved to their project settings.
- [x] (obvious but I almost missed it) Confirm that the priorities were removed from project settings