### PR TITLE
Ensure that export-time plugin priorities are used in all cases

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -638,7 +638,7 @@ Vector<PluginConfigAndroid> EditorExportPlatformAndroid::get_enabled_plugins(con
 
 	String plugins_dir = ProjectSettings::get_singleton()->get_resource_path().plus_file("android/plugins");
 	// Add the prebuilt plugins
-	enabled_plugins.append_array(PluginConfigAndroid::get_prebuilt_plugins(plugins_dir));
+	enabled_plugins.append_array(PluginConfigAndroid::get_prebuilt_plugins(plugins_dir, p_presets));
 
 	Vector<PluginConfigAndroid> all_plugins = get_plugins();
 	for (int i = 0; i < all_plugins.size(); i++) {

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -90,9 +90,9 @@ PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAnd
 	return resolved;
 }
 
-Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plugins_base_dir) {
+Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plugins_base_dir, const Ref<EditorExportPreset> &p_preset) {
 	Vector<PluginConfigAndroid> prebuilt_plugins;
-	Array plugin_keys = AdServer::get_singleton()->get_plugin_priority_order();
+	Array plugin_keys = p_preset->get("ramatak/monetization/ad_plugin_priorities");
 	for (int plugin_idx = 0; plugin_idx < plugin_keys.size(); plugin_idx++) {
 		Ref<ConfigFile> config;
 		config.instance();

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -35,6 +35,7 @@
 #include "core/io/config_file.h"
 #include "core/project_settings.h"
 #include "core/ustring.h"
+#include "editor/editor_export.h"
 
 /*
  The `config` section and fields are required and defined as follow:
@@ -88,7 +89,7 @@ struct PluginConfigAndroid {
 
 	static PluginConfigAndroid resolve_prebuilt_plugin(PluginConfigAndroid prebuilt_plugin, String plugin_config_dir);
 
-	static Vector<PluginConfigAndroid> get_prebuilt_plugins(String plugins_base_dir);
+	static Vector<PluginConfigAndroid> get_prebuilt_plugins(String plugins_base_dir, const Ref<EditorExportPreset> &p_preset);
 
 	static bool is_plugin_config_valid(PluginConfigAndroid plugin_config);
 


### PR DESCRIPTION
This fixes a bug that is causing project settings priorities to be used in place of export time settings, which is a big problem now that we've removed the project settings priorities UI.