### PR TITLE
Update android SDK versions for XMediator

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -226,8 +226,8 @@ static const int EXPORT_FORMAT_AAB = 1;
 static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
 static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/installTime/src/main/assets";
 
-static const int DEFAULT_MIN_SDK_VERSION = 19; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
-static const int DEFAULT_TARGET_SDK_VERSION = 32; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_MIN_SDK_VERSION = 24; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 33; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 static const int KEY_FROM_MANAGER = 0;
 static const int KEY_FROM_MANUAL = 1;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -260,7 +260,7 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_read_write_storage_permission) {
 	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
 	bool uses_xr = xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR;
-Array ad_priorities = AdServer::get_singleton()->get_plugin_priority_order();
+	Array ad_priorities = AdServer::get_singleton()->get_plugin_priority_order();
 	String maybe_add_cleartext_traffic_for_fb = "";
 	if (ad_priorities.has("META")) {
 		maybe_add_cleartext_traffic_for_fb = "        android:usesCleartextTraffic=\"true\"\n";
@@ -272,7 +272,7 @@ Array ad_priorities = AdServer::get_singleton()->get_plugin_priority_order();
 			"        android:isGame=\"%s\"\n"
 			"        android:hasFragileUserData=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
-"%s"
+			"%s"
 			"        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
 			"        tools:ignore=\"GoogleAppIndexingWarning\"\n"
 			"        android:icon=\"@mipmap/icon\" >\n\n"
@@ -304,12 +304,14 @@ Array ad_priorities = AdServer::get_singleton()->get_plugin_priority_order();
 	}
 
 	Dictionary admob_config = AdServer::get_singleton()->get_plugin_config("ADMOB");
-	if (ad_priorities.has("ADMOB") && admob_config.has("application_id")) {
+	if (admob_config.has("application_id")) {
 		// Update the meta-data 'android:name' attribute based on whether Admob is required.
 		String admob_app_id = admob_config["application_id"];
 		manifest_application_text += "        <meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" android:value=\"" + admob_app_id + "\" />\n";
 	} else if (ad_priorities.has("ADMOB")) {
 		WARN_PRINT("Missing Admob application_id config setting. Exported game may crash on startup.");
+	} else if (ad_priorities.has("XMEDIATOR")) {
+		WARN_PRINT("Missing Admob application_id config setting. Exported game may crash on startup if Admob is enabled.");
 	}
 
 	manifest_application_text += _get_activity_tag(p_preset);

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,9 +1,9 @@
 ext.versions = [
     androidGradlePlugin: '7.0.3',
-    compileSdk         : 32,
-    minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
-    targetSdk          : 32, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
-    buildTools         : '32.0.0',
+    compileSdk         : 33,
+    minSdk             : 24, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    targetSdk          : 33, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
+    buildTools         : '33.0.0',
     kotlinVersion      : '1.6.21',
     fragmentVersion    : '1.3.6',
     nexusPublishVersion: '1.1.0',

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0">
 
     <!-- Should match the mindSdk and targetSdk values in platform/android/java/app/config.gradle -->
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="32" />
+    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="32" />
 
     <application>
 


### PR DESCRIPTION
This updates sdk versions to let us perform xmediatior exports. The old minimum SDK level was lower than XMediator's minimum SDK level, and there were other compatibility issues that prevented successful builds.