### PR TITLE
Add an ads status label and debug/coppa toggles

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1011,9 +1011,12 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		}
 	}
 
-	Array ramatak_ad_plugin_priorities = p_preset->get("ramatak/monetization/ad_plugin_priorities");
-	if (ramatak_ad_plugin_priorities.size() > 0) {
-		custom_map["ramatak/monetization/ad_plugin_priorities"] = ramatak_ad_plugin_priorities;
+	List<PropertyInfo> all_preset_properties = p_preset->get_properties();
+	for (List<PropertyInfo>::Element *E = all_preset_properties.front(); E; E = E->next()) {
+		PropertyInfo pi = E->get();
+		if (pi.name.begins_with("ramatak/")) {
+			custom_map[pi.name] = p_preset->get(pi.name);
+		}
 	}
 
 	String config_file = "project.binary";

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -303,6 +303,10 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 			break;
 		}
 	}
+	while (ramatak_status_label_container->get_child_count() > 0) {
+		ramatak_status_label_container->remove_child(ramatak_status_label_container->get_child(0));
+	}
+
 	if (current->get_platform()->ad_plugins_supported()) {
 		VBoxContainer *ramtak_vb = memnew(VBoxContainer);
 		ramtak_vb->set_name(TTR("Ramatak"));
@@ -310,6 +314,8 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		ramatak_export_settings->set_preset(current);
 		ramtak_vb->add_child(ramatak_export_settings);
 		sections->add_child(ramtak_vb);
+
+		ramatak_status_label_container->add_child(ramatak_export_settings->get_status_label());
 	}
 
 	int script_export_mode = current->get_script_export_mode();
@@ -1032,9 +1038,15 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	// Preset settings.
 
+	ScrollContainer *preset_settings_scroll = memnew(ScrollContainer);
+	preset_settings_scroll->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	preset_settings_scroll->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	hbox->add_child(preset_settings_scroll);
+
 	VBoxContainer *settings_vb = memnew(VBoxContainer);
 	settings_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hbox->add_child(settings_vb);
+	settings_vb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	preset_settings_scroll->add_child(settings_vb);
 
 	name = memnew(LineEdit);
 	settings_vb->add_margin_child(TTR("Name:"), name);
@@ -1205,6 +1217,14 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_pck_zip->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	add_child(export_pck_zip);
 	export_pck_zip->connect("file_selected", this, "_export_pck_zip_selected");
+
+	// Container for Ramatak status label.
+
+	ramatak_status_label_container = memnew(BoxContainer);
+	ramatak_status_label_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	settings_vb->add_child(ramatak_status_label_container);
+
+	// Errors and warnings.
 
 	export_error = memnew(Label);
 	main_vb->add_child(export_error);

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -59,6 +59,8 @@ class ProjectExportDialog : public ConfirmationDialog {
 	GDCLASS(ProjectExportDialog, ConfirmationDialog);
 
 private:
+	Container *ramatak_status_label_container;
+
 	TabContainer *sections;
 
 	MenuButton *add_preset;

--- a/editor/ramatak/ramatak_export_settings.cpp
+++ b/editor/ramatak/ramatak_export_settings.cpp
@@ -5,6 +5,8 @@
 #include "editor/editor_export.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
@@ -14,13 +16,37 @@
 #include "servers/ramatak/ad_server.h"
 
 RamatakExportSettingsEditor::RamatakExportSettingsEditor() {
-	main_hbox = memnew(HBoxContainer);
-	main_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
-	add_child(main_hbox);
+	main_vbox = memnew(VBoxContainer);
+	main_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(main_vbox);
 
-	HSplitContainer *hsplit = memnew(HSplitContainer);
-	hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	main_hbox->add_child(hsplit);
+	HFlowContainer *checkbox_row = memnew(HFlowContainer);
+	checkbox_row->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+	debug_checkbox = memnew(CheckBox);
+	debug_checkbox->set_text("Advertisement Debug/Developer Mode");
+	debug_checkbox->connect("toggled", this, "_debug_checkbox_toggled");
+	checkbox_row->add_child(debug_checkbox);
+
+	child_directed_checkbox = memnew(CheckBox);
+	child_directed_checkbox->set_text("Project is child-directed");
+	child_directed_checkbox->connect("toggled", this, "_child_directed_checkbox_toggled");
+	checkbox_row->add_child(child_directed_checkbox);
+
+	main_vbox->add_child(checkbox_row);
+
+	status_label = memnew(Label);
+	status_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	status_label->set_autowrap(true);
+
+	priorities_hbox = memnew(HBoxContainer);
+	priorities_hbox->set_anchors_and_margins_preset(LayoutPreset::PRESET_WIDE, LayoutPresetMode::PRESET_MODE_KEEP_SIZE);
+	main_vbox->add_child(priorities_hbox);
+
+	HSplitContainer *priorities_hsplit = memnew(HSplitContainer);
+	priorities_hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	priorities_hbox->add_child(priorities_hsplit);
 
 	VBoxContainer *disabled_plugins_vbox = memnew(VBoxContainer);
 	disabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -28,13 +54,14 @@ RamatakExportSettingsEditor::RamatakExportSettingsEditor() {
 	disabled_plugins_list = memnew(ItemList);
 	disabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	disabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	disabled_plugins_list->connect("item_selected", this, "_disabled_plugins_list_item_selected");
 
 	Label *disabled_plugins_label = memnew(Label);
 	disabled_plugins_label->set_text("Disabled Plugins:");
 
 	disabled_plugins_vbox->add_child(disabled_plugins_label);
 	disabled_plugins_vbox->add_child(disabled_plugins_list);
-	hsplit->add_child(disabled_plugins_vbox);
+	priorities_hsplit->add_child(disabled_plugins_vbox);
 
 	VBoxContainer *enabled_plugins_vbox = memnew(VBoxContainer);
 	enabled_plugins_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -42,16 +69,17 @@ RamatakExportSettingsEditor::RamatakExportSettingsEditor() {
 	enabled_plugins_list = memnew(ItemList);
 	enabled_plugins_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	enabled_plugins_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	enabled_plugins_list->connect("item_selected", this, "_enabled_plugins_list_item_selected");
 
 	Label *enabled_plugins_label = memnew(Label);
 	enabled_plugins_label->set_text("Enabled Plugins:");
 
 	enabled_plugins_vbox->add_child(enabled_plugins_label);
 	enabled_plugins_vbox->add_child(enabled_plugins_list);
-	hsplit->add_child(enabled_plugins_vbox);
+	priorities_hsplit->add_child(enabled_plugins_vbox);
 
 	button_row = memnew(VBoxContainer);
-	main_hbox->add_child(button_row);
+	priorities_hbox->add_child(button_row);
 
 	// Make buttons align with the plugin lists.
 	button_row->add_child(memnew(Label(" ")));
@@ -80,7 +108,7 @@ RamatakExportSettingsEditor::RamatakExportSettingsEditor() {
 void RamatakExportSettingsEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		Array all_plugins = AdServer::get_singleton()->get_available_plugins();
-		Array priority_order = preset->get("ramatak/monetization/ad_plugin_priorities");
+		Array priority_order = preset->get(AD_PLUGIN_PRIORITIES_KEY);
 		for (int i = 0; i < priority_order.size(); i++) {
 			enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(priority_order[i])->get_friendly_name());
 			enabled_plugins_list->set_item_metadata(i, (String)priority_order[i]);
@@ -91,7 +119,62 @@ void RamatakExportSettingsEditor::_notification(int p_what) {
 				disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, (String)all_plugins[i]);
 			}
 		}
+		debug_checkbox->set_pressed(preset->get(AD_DEBUG_MODE_KEY));
+		child_directed_checkbox->set_pressed(preset->get(AD_CHILD_DIRECTED_KEY));
+		update_status_label();
 	}
+}
+
+void RamatakExportSettingsEditor::update_status_label() {
+	if (preset == nullptr) {
+		status_label->set_text("");
+		return;
+	}
+	String status = "";
+
+	Array revenue_generating_plugins;
+	Array enabled_plugins = preset->get(AD_PLUGIN_PRIORITIES_KEY);
+	for (int i = 0; i < enabled_plugins.size(); i++) {
+		if (enabled_plugins[i] == "DUMMY") {
+			continue;
+		}
+		revenue_generating_plugins.push_back(enabled_plugins[i]);
+	}
+
+	if (revenue_generating_plugins.size() > 0) {
+		for (int i = 0; i < revenue_generating_plugins.size(); i++) {
+			String plugin_id = revenue_generating_plugins[i];
+			status += AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name();
+			if (i != revenue_generating_plugins.size() - 1) {
+				if (i == revenue_generating_plugins.size() - 2) {
+					status += " and ";
+				} else {
+					status += ", ";
+				}
+			}
+		}
+		if (revenue_generating_plugins.size() > 1) {
+			status += " are enabled.";
+		} else {
+			status += " is enabled.";
+		}
+
+		if (preset->get(AD_DEBUG_MODE_KEY)) {
+			status += " Debug mode is enabled, ads will NOT generate revenue.";
+		} else {
+			status += " Debug mode is disabled, ads will generate revenue but testing with live ads is against the terms of service for some ad networks.";
+		}
+
+		if (preset->get(AD_CHILD_DIRECTED_KEY)) {
+			status += " This project is marked as child-directed. Advertisement delivery will be suitable for children.";
+		} else {
+			status += " This project is marked as not child-directed. Advertisements may not be suitable for children.";
+		}
+	} else {
+		status += "No revenue-generating advertisement plugins are enabled.";
+	}
+
+	status_label->set_text(status);
 }
 
 void RamatakExportSettingsEditor::_bind_methods() {
@@ -99,6 +182,10 @@ void RamatakExportSettingsEditor::_bind_methods() {
 	ClassDB::bind_method("_decrease_selected_priority", &RamatakExportSettingsEditor::_decrease_selected_priority);
 	ClassDB::bind_method("_enable_selected_plugin", &RamatakExportSettingsEditor::_enable_selected_plugin);
 	ClassDB::bind_method("_disable_selected_plugin", &RamatakExportSettingsEditor::_disable_selected_plugin);
+	ClassDB::bind_method("_enabled_plugins_list_item_selected", &RamatakExportSettingsEditor::_enabled_plugins_list_item_selected);
+	ClassDB::bind_method("_disabled_plugins_list_item_selected", &RamatakExportSettingsEditor::_disabled_plugins_list_item_selected);
+	ClassDB::bind_method("_debug_checkbox_toggled", &RamatakExportSettingsEditor::_debug_checkbox_toggled);
+	ClassDB::bind_method("_child_directed_checkbox_toggled", &RamatakExportSettingsEditor::_child_directed_checkbox_toggled);
 }
 
 int RamatakExportSettingsEditor::get_selected_index(ItemList *p_list) {
@@ -119,7 +206,7 @@ void RamatakExportSettingsEditor::persist_settings() {
 		String id = enabled_plugins_list->get_item_metadata(i);
 		priorities.push_back(id);
 	}
-	preset->set("ramatak/monetization/ad_plugin_priorities", priorities);
+	preset->set(AD_PLUGIN_PRIORITIES_KEY, priorities);
 }
 
 void RamatakExportSettingsEditor::_increase_selected_priority() {
@@ -158,6 +245,7 @@ void RamatakExportSettingsEditor::_enable_selected_plugin() {
 	enabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
 	enabled_plugins_list->set_item_metadata(enabled_plugins_list->get_item_count() - 1, plugin_id);
 	persist_settings();
+	update_status_label();
 }
 
 void RamatakExportSettingsEditor::_disable_selected_plugin() {
@@ -170,8 +258,32 @@ void RamatakExportSettingsEditor::_disable_selected_plugin() {
 	disabled_plugins_list->add_item(AdServer::get_singleton()->get_plugin_raw(plugin_id)->get_friendly_name());
 	disabled_plugins_list->set_item_metadata(disabled_plugins_list->get_item_count() - 1, plugin_id);
 	persist_settings();
+	update_status_label();
+}
+
+void RamatakExportSettingsEditor::_enabled_plugins_list_item_selected(int p_index) {
+	disabled_plugins_list->unselect_all();
+}
+
+void RamatakExportSettingsEditor::_disabled_plugins_list_item_selected(int p_index) {
+	enabled_plugins_list->unselect_all();
+}
+
+void RamatakExportSettingsEditor::_debug_checkbox_toggled(bool p_pressed) {
+	preset->set(AD_DEBUG_MODE_KEY, p_pressed);
+	update_status_label();
+}
+
+void RamatakExportSettingsEditor::_child_directed_checkbox_toggled(bool p_pressed) {
+	preset->set(AD_CHILD_DIRECTED_KEY, p_pressed);
+	update_status_label();
+}
+
+Control *RamatakExportSettingsEditor::get_status_label() {
+	return status_label;
 }
 
 void RamatakExportSettingsEditor::set_preset(Ref<EditorExportPreset> p_preset) {
 	preset = p_preset;
+	update_status_label();
 }

--- a/editor/ramatak/ramatak_export_settings.h
+++ b/editor/ramatak/ramatak_export_settings.h
@@ -11,6 +11,8 @@ class GridContainer;
 class OptionButton;
 class LineEdit;
 class Button;
+class Control;
+class CheckBox;
 class ItemList;
 class Label;
 class EditorExportPreset;
@@ -18,7 +20,13 @@ class EditorExportPreset;
 class RamatakExportSettingsEditor : public Control {
 	GDCLASS(RamatakExportSettingsEditor, Control);
 
-	HBoxContainer *main_hbox = nullptr;
+	VBoxContainer *main_vbox = nullptr;
+	HBoxContainer *priorities_hbox = nullptr;
+
+	CheckBox *debug_checkbox = nullptr;
+	CheckBox *child_directed_checkbox = nullptr;
+
+	Label *status_label = nullptr;
 
 	ItemList *disabled_plugins_list = nullptr;
 	ItemList *enabled_plugins_list = nullptr;
@@ -38,6 +46,8 @@ class RamatakExportSettingsEditor : public Control {
 protected:
 	static void _bind_methods();
 
+	void update_status_label();
+
 	void _notification(int p_what);
 
 	void _increase_selected_priority();
@@ -46,8 +56,16 @@ protected:
 	void _enable_selected_plugin();
 	void _disable_selected_plugin();
 
+	void _enabled_plugins_list_item_selected(int p_index);
+	void _disabled_plugins_list_item_selected(int p_index);
+
+	void _debug_checkbox_toggled(bool p_pressed);
+	void _child_directed_checkbox_toggled(bool p_pressed);
+
 public:
 	void set_preset(Ref<EditorExportPreset> p_preset);
+
+	Control *get_status_label();
 
 	RamatakExportSettingsEditor();
 };

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1768,6 +1768,8 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "apk_expansion/public_key", PROPERTY_HINT_MULTILINE_TEXT), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "ramatak/monetization/ad_plugin_priorities"), Dictionary()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/child_directed"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::POOL_STRING_ARRAY, "permissions/custom_permissions"), PoolStringArray()));
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -304,14 +304,18 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 	}
 
 	Dictionary admob_config = AdServer::get_singleton()->get_plugin_config("ADMOB");
-	if (admob_config.has("application_id")) {
+	Dictionary xmediator_config = AdServer::get_singleton()->get_plugin_config("XMEDIATOR");
+	if (admob_config.has("application_id") && ((String)admob_config["application_id"]) != "") {
 		// Update the meta-data 'android:name' attribute based on whether Admob is required.
 		String admob_app_id = admob_config["application_id"];
-		manifest_application_text += "        <meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" android:value=\"" + admob_app_id + "\" />\n";
+		manifest_application_text += "        <meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" android:value=\"" + admob_app_id.strip_edges() + "\" />\n";
 	} else if (ad_priorities.has("ADMOB")) {
 		WARN_PRINT("Missing Admob application_id config setting. Exported game may crash on startup.");
-	} else if (ad_priorities.has("XMEDIATOR")) {
-		WARN_PRINT("Missing Admob application_id config setting. Exported game may crash on startup if Admob is enabled.");
+	}
+	if (xmediator_config.has("android_google_ads_application_id") && ((String)xmediator_config["android_google_ads_application_id"]) != "") {
+		// Update the meta-data 'android:name' attribute based on whether Admob is required.
+		String admob_app_id = xmediator_config["android_google_ads_application_id"];
+		manifest_application_text += "        <meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" android:value=\"" + admob_app_id.strip_edges() + "\" />\n";
 	}
 
 	manifest_application_text += _get_activity_tag(p_preset);

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -281,7 +281,7 @@ public:
 				}
 			}
 		}
-		
+
 		return loaded_plugins;
 	}
 
@@ -437,6 +437,8 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::COLOR, "storyboard/custom_bg_color"), Color()));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "ramatak/monetization/ad_plugin_priorities"), Dictionary()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/child_directed"), false));
 
 	for (uint64_t i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, loading_screen_infos[i].preset_key, PROPERTY_HINT_FILE, "*.png,*.jpg,*.jpeg"), ""));
@@ -1911,7 +1913,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			result_linker_flags += flag;
 		}
 		result_linker_flags = result_linker_flags.replace("\"", "\\\"");
-		
+
 		if (result_linker_flags.find("-ObjC") == -1) {
 			result_linker_flags += " -ObjC";
 		}
@@ -2203,8 +2205,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		ERR_PRINT("Can't copy '" + builtin_lib_path + "'.");
 		memdelete(tmp_app_path);
 		return lib_copy_err;
-	}
-	else {
+	} else {
 		config_data.linker_flags += " -Fframeworks";
 	}
 

--- a/servers/ramatak/ad_plugin.cpp
+++ b/servers/ramatak/ad_plugin.cpp
@@ -1,4 +1,5 @@
 #include "ad_plugin.h"
+#include "core/project_settings.h"
 
 void AdPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("init_plugin"), &AdPlugin::init_plugin);
@@ -13,4 +14,12 @@ void AdPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(AUTH_ERROR);
 	BIND_ENUM_CONSTANT(NETWORK_ERROR);
 	BIND_ENUM_CONSTANT(UNSPECIFIED_ERROR);
+}
+
+bool AdPlugin::_get_debug_mode() const {
+	return ProjectSettings::get_singleton()->get_setting(AD_DEBUG_MODE_KEY);
+}
+
+bool AdPlugin::_get_child_directed() const {
+	return ProjectSettings::get_singleton()->get_setting(AD_CHILD_DIRECTED_KEY);
 }

--- a/servers/ramatak/ad_plugin.h
+++ b/servers/ramatak/ad_plugin.h
@@ -6,11 +6,19 @@
 #include "core/reference.h"
 #include "servers/ramatak/ad_server.h"
 
+// If you add settings here you must also add them to the preset settings in EditorExportPlatformIOS::get_export_options and  EditorExportPlatformAndroid::get_export_options
+#define AD_PLUGIN_PRIORITIES_KEY "ramatak/monetization/ad_plugin_priorities"
+#define AD_DEBUG_MODE_KEY "ramatak/monetization/debug_mode"
+#define AD_CHILD_DIRECTED_KEY "ramatak/monetization/child_directed"
+
 class AdPlugin : public Reference {
 	GDCLASS(AdPlugin, Reference);
 
 protected:
 	static void _bind_methods();
+
+	bool _get_debug_mode() const;
+	bool _get_child_directed() const;
 
 public:
 	enum AdPluginResult {


### PR DESCRIPTION
Adds a status label to make sure users know exactly what is happening behind the scenes, and add toggles for child-directedness and debug/developer modes. This also plumbs those settings through into the exported app's project settings.

![Screenshot from 2024-01-12 13-52-26](https://github.com/ramatakinc/godot/assets/1936763/fd3bd370-db87-48db-a1e0-7e0a00ff02d8)
