### PR TITLE
Core changes to support automatic debug placements

### DIFF
--- a/editor/ramatak/ramatak_settings_editor.cpp
+++ b/editor/ramatak/ramatak_settings_editor.cpp
@@ -390,7 +390,23 @@ void RamatakAdPluginSettingsEditor::clear() {
 
 RamatakSettingsEditor::RamatakSettingsEditor() {
 	if (!ProjectSettings::get_singleton()->has_setting("ramatak/monetization/ad_units")) {
-		ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", Dictionary());
+		Dictionary ad_units;
+		{
+			Dictionary ad_unit = Dictionary();
+			ad_unit["ad_unit_type"] = AdServer::AD_TYPE_BANNER;
+			ad_units["default_banner"] = ad_unit;
+		}
+		{
+			Dictionary ad_unit = Dictionary();
+			ad_unit["ad_unit_type"] = AdServer::AD_TYPE_INTERSTITIAL;
+			ad_units["default_interstitial"] = ad_unit;
+		}
+		{
+			Dictionary ad_unit = Dictionary();
+			ad_unit["ad_unit_type"] = AdServer::AD_TYPE_REWARDED;
+			ad_units["default_rewarded"] = ad_unit;
+		}
+		ProjectSettings::get_singleton()->set("ramatak/monetization/ad_units", ad_units);
 	}
 	ProjectSettings::get_singleton()->set_initial_value("ramatak/monetization/ad_units", Dictionary());
 

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1768,7 +1768,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "apk_expansion/public_key", PROPERTY_HINT_MULTILINE_TEXT), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "ramatak/monetization/ad_plugin_priorities"), Dictionary()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/child_directed"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::POOL_STRING_ARRAY, "permissions/custom_permissions"), PoolStringArray()));

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -437,7 +437,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::COLOR, "storyboard/custom_bg_color"), Color()));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "ramatak/monetization/ad_plugin_priorities"), Dictionary()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/debug_mode"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ramatak/monetization/child_directed"), false));
 
 	for (uint64_t i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {

--- a/servers/ramatak/ad_server.cpp
+++ b/servers/ramatak/ad_server.cpp
@@ -99,7 +99,7 @@ Variant AdServer::show_other(String p_ad_unit) {
 
 	for (int i = 0; i < ad_plugin_priorities.size(); i++) {
 		String network_specific_id = MonetizationSettings::get_singleton()->get_ad_unit_network_id(p_ad_unit, ad_plugin_priorities[i]);
-		if (network_specific_id.length() > 0) {
+		if (network_specific_id.length() > 0 || project_settings->get("ramatak/monetization/debug_mode")) {
 			// Plugin `i` can handle the specified ad_unit.
 			Variant request_token = rand.rand() & 0x7FFFFFFF;
 			ad_plugins[ad_plugin_priorities[i]]->show_other(network_specific_id, request_token, (AdServer::AdType)ad_type);
@@ -131,10 +131,11 @@ Variant AdServer::show_banner(String p_ad_unit, BannerAdSize p_size, BannerAdLoc
 	} else {
 		ERR_FAIL_V_MSG(Variant(), "Ad location not handled");
 	}
-	Array ad_plugin_priorities = (Array)ProjectSettings::get_singleton()->get("ramatak/monetization/ad_plugin_priorities");
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	Array ad_plugin_priorities = (Array)project_settings->get("ramatak/monetization/ad_plugin_priorities");
 	for (int i = 0; i < ad_plugin_priorities.size(); i++) {
 		String network_specific_id = MonetizationSettings::get_singleton()->get_ad_unit_network_id(p_ad_unit, ad_plugin_priorities[i]);
-		if (network_specific_id.length() > 0) {
+		if (network_specific_id.length() > 0 || project_settings->get("ramatak/monetization/debug_mode")) {
 			// Plugin `i` can handle the specified ad_unit.
 			Variant request_token = rand.rand() & 0x7FFFFFFF;
 			ad_plugins[ad_plugin_priorities[i]]->show_banner(network_specific_id, request_token, size, location);


### PR DESCRIPTION
This supports the seamless use of debug placement IDs in Mobile Studio.

See also the tandem PRs in the modules repo and android plugins repo.